### PR TITLE
update: 사용자가 선택한 book 아이템을 DB에서 삭제

### DIFF
--- a/app/lib/actions.ts
+++ b/app/lib/actions.ts
@@ -4,22 +4,19 @@ import db from '@/lib/db';
 import { revalidatePath } from 'next/cache';
 
 export async function deleteBooks(ids: number[]) {
-  console.log('delete books: ', ids);
-  // TODO: 복수의 데이터 일괄 삭제 서버 액션
-  //! NOT WORKING
-  // 현재는 DELETE가 아닌 POST 메소드가 호출되고 있음 : POST /mine?mode=edit&items=2 200
-  //   try {
-  //     const deleteResult = await db.book.deleteMany({
-  //       where: {
-  //         id: {
-  //           in: ids,
-  //         },
-  //       },
-  //     });
-  //     console.log(`Deletion result:`, deleteResult);
-  //     revalidatePath('/mine');
-  //     return { message: 'Deleted Books.' };
-  //   } catch (error) {
-  //     return { message: 'Database Error: Failed to Delete Books.' };
-  //   }
+  try {
+    await db.book.deleteMany({
+      where: {
+        id: {
+          in: ids,
+        },
+      },
+    });
+    console.log('Books deleted successfully');
+    revalidatePath('/mine');
+    return { message: 'Deleted Books.' };
+  } catch (error) {
+    console.error('Error deleting books:', error);
+    return { message: 'Database Error: Failed to Delete Books.' };
+  }
 }

--- a/app/ui/bookshelf/buttons.tsx
+++ b/app/ui/bookshelf/buttons.tsx
@@ -1,21 +1,39 @@
+import { useState } from 'react';
+import { useSearchParams, usePathname, useRouter } from 'next/navigation';
 import clsx from 'clsx';
 import { PlusIcon, TrashIcon, Bars3BottomLeftIcon } from '@heroicons/react/24/outline';
 import { deleteBooks } from '@/lib/actions';
+import { SELECTED_ITEMS_KEY } from '@/constants';
 
 export function DeleteBooks({ ids }: { ids: number[] }) {
-  const disabled = ids.length === 0;
-  const deleteBooksWithIds = deleteBooks.bind(null, ids);
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const { replace } = useRouter();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const disabled = ids.length === 0 || isDeleting;
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    try {
+      await deleteBooks(ids);
+      const params = new URLSearchParams(searchParams);
+      params.delete(SELECTED_ITEMS_KEY);
+      replace(`${pathname}?${params.toString()}`);
+    } catch (error) {
+      console.error('Error deleting books:', error);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
 
   return (
-    <form action={deleteBooksWithIds}>
-      <button disabled={disabled}>
-        <TrashIcon
-          className={clsx('size-6 font-bold', {
-            'text-main-theme-color': ids.length > 0,
-            'text-neutral-400': disabled,
-          })}
-        />
-      </button>
-    </form>
+    <button onClick={handleDelete} disabled={disabled}>
+      <TrashIcon
+        className={clsx('size-6 font-bold', {
+          'text-main-theme-color': ids.length > 0,
+          'text-neutral-400': disabled,
+        })}
+      />
+    </button>
   );
 }

--- a/app/ui/bookshelf/header.tsx
+++ b/app/ui/bookshelf/header.tsx
@@ -43,7 +43,6 @@ function ActionButtons() {
   const currentMode = searchParams.get('mode') || 'view';
   const selectedItemsParam = searchParams.get(SELECTED_ITEMS_KEY);
   const selectedItems = selectedItemsParam ? selectedItemsParam.split(',').map(Number) : [];
-  console.log('items', selectedItems);
 
   return (
     <div className="w-[28px] flex gap-3">

--- a/prisma/migrations/20240707104204_add_cascade_delete/migration.sql
+++ b/prisma/migrations/20240707104204_add_cascade_delete/migration.sql
@@ -1,0 +1,25 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_AuthorBook" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "bookId" INTEGER NOT NULL,
+    "authorId" INTEGER NOT NULL,
+    CONSTRAINT "AuthorBook_bookId_fkey" FOREIGN KEY ("bookId") REFERENCES "Book" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "AuthorBook_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "Author" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_AuthorBook" ("authorId", "bookId", "id") SELECT "authorId", "bookId", "id" FROM "AuthorBook";
+DROP TABLE "AuthorBook";
+ALTER TABLE "new_AuthorBook" RENAME TO "AuthorBook";
+CREATE TABLE "new_TranslatorBook" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "bookId" INTEGER NOT NULL,
+    "translatorId" INTEGER NOT NULL,
+    CONSTRAINT "TranslatorBook_bookId_fkey" FOREIGN KEY ("bookId") REFERENCES "Book" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "TranslatorBook_translatorId_fkey" FOREIGN KEY ("translatorId") REFERENCES "Translator" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_TranslatorBook" ("bookId", "id", "translatorId") SELECT "bookId", "id", "translatorId" FROM "TranslatorBook";
+DROP TABLE "TranslatorBook";
+ALTER TABLE "new_TranslatorBook" RENAME TO "TranslatorBook";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,9 +59,9 @@ model Author {
 // 중간 테이블
 model AuthorBook {
   id       Int    @id @default(autoincrement())
-  book     Book   @relation(fields: [bookId], references: [id])
+  book     Book   @relation(fields: [bookId], references: [id], onDelete: Cascade)
   bookId   Int
-  author   Author @relation(fields: [authorId], references: [id])
+  author   Author @relation(fields: [authorId], references: [id], onDelete: Cascade)
   authorId Int
 }
 
@@ -74,8 +74,8 @@ model Translator {
 // 중간 테이블
 model TranslatorBook {
   id           Int        @id @default(autoincrement())
-  book         Book       @relation(fields: [bookId], references: [id])
+  book         Book       @relation(fields: [bookId], references: [id], onDelete: Cascade)
   bookId       Int
-  Translator   Translator @relation(fields: [translatorId], references: [id])
+  Translator   Translator @relation(fields: [translatorId], references: [id], onDelete: Cascade)
   translatorId Int
 }


### PR DESCRIPTION
closes #13 

`Book` 모델이 `AuthorBook` 및 `TranslatorBook` 모델과 관계를 맺고 있으므로, `Book`을 삭제하려면 먼저 이 관계들을 처리해야 한다. 
중간 테이블 역할을 하는 `AuthorBook` 및 `TranslatorBook` 에서 book에 대해 onDelete `Cascade` 설정 

DB 삭제 이후 queryString의 `SELECTED_ITEMS_KEY`도 삭제해주어야 해서 `DeleteBooks` 컴포넌트에서 서버 액션으로만 처리할 수 없었음. `handleDelete` 함수의 try 절에서 params.delete() 로직 추가함. 