### PR TITLE
feat: 책 상세 페이지 구현 

### DIFF
--- a/app/books/[id]/page.tsx
+++ b/app/books/[id]/page.tsx
@@ -1,0 +1,115 @@
+import Image from 'next/image';
+import { notFound } from 'next/navigation';
+import db from '@/lib/db';
+import HeaderLayout from '@/layout/header';
+import { getImageSize } from '@/utils/image';
+
+type Props = {
+  params: { id: string };
+};
+
+async function getBook(id: number) {
+  const book = await db.book.findUnique({
+    where: {
+      id,
+    },
+    include: {
+      authors: {
+        include: {
+          author: true,
+        },
+      },
+      translators: {
+        include: {
+          translator: true,
+        },
+      },
+    },
+  });
+
+  return book;
+}
+
+export default async function BookDetail({ params }: Props) {
+  const id = Number(params.id);
+  // url에 /books/abc 처럼 숫자가 아닌 id를 직접 입력하고 진입할 때
+  if (Number.isNaN(id)) return notFound();
+
+  const book = await getBook(id);
+  // db에 해당 id의 book이 없을 때
+  if (!book) return notFound();
+
+  const { title, thumbnail, datetime, price, authors, translators, publisher, url, isbn, rating, review, created_at } =
+    book;
+
+  const { width, height } = getImageSize(thumbnail);
+
+  const authorNames = authors.map((author) => author.author.name);
+  const translatorNames = translators.map((translator) => translator.translator.name);
+  const basicInfoItems = [
+    `${authorNames.join(', ')} 지음`,
+    translatorNames.length > 0 ? `${translatorNames.join(', ')} 옮김` : null,
+    publisher,
+  ];
+
+  return (
+    <>
+      {/* //TODO: Header 버튼 스타일링 및 액션 입히기 */}
+      <HeaderLayout>
+        <span>뒤로</span>
+        <button>편집</button>
+      </HeaderLayout>
+
+      <section className="min-h-screen pb-10 flex flex-col gap-12 bg-zinc-100 *:bg-white">
+        <div>
+          <h3 className="pt-2 pb-4 text-xl font-semibold text-center">{title}</h3>
+          <div className="px-6 py-2 flex justify-between">
+            {width && height ? (
+              <Image src={thumbnail} alt={title} className="border shadow-xl" width={width} height={height} priority />
+            ) : (
+              <span className="w-[120px] h-[174px] flex items-center text-center bg-gray-400">
+                Invalid thumbnail URL
+              </span>
+            )}
+            <div className="flex flex-col justify-end items-end *:text-neutral-500">
+              <span>{datetime.toLocaleString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' })}</span>
+              <span>{price.toLocaleString('ko-KR')}원</span>
+              <span>{isbn.split(' ')[1]}</span>
+            </div>
+          </div>
+          <div className="pl-4 flex flex-col gap-2 border-y-[1px]">
+            {basicInfoItems.map(
+              (item, index) =>
+                item && (
+                  <p key={index} className="py-3 border-b-[1px] last:border-b-0">
+                    {item}
+                  </p>
+                ),
+            )}
+          </div>
+        </div>
+
+        <div className="pl-4 flex flex-col gap-2 border-y-[1px]">
+          <p className="py-3 border-b-[1px] last:border-b-0">별점: {rating}</p>
+          {review && <p className="py-3 border-b-[1px] last:border-b-0">한 줄 평: {review}</p>}
+        </div>
+
+        <div
+          data-before="등록일"
+          className="before:content-[attr(data-before)] before:absolute before:-translate-y-8 before:text-neutral-500 pl-4 flex flex-col gap-2 border-y-[1px]"
+        >
+          <p className="py-3 border-b-[1px] last:border-b-0">
+            {created_at.toLocaleString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' })}
+          </p>
+        </div>
+
+        <div
+          data-before="도서 정보는 Daum에서 제공합니다."
+          className="before:content-[attr(data-before)] before:absolute before:-translate-y-8 before:text-neutral-500 pl-4 flex flex-col gap-2 border-y-[1px]"
+        >
+          <p className="py-3 border-b-[1px] last:border-b-0">다음 검색에서 보기</p>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/app/books/[id]/page.tsx
+++ b/app/books/[id]/page.tsx
@@ -6,6 +6,11 @@ import { getImageSize } from '@/utils/image';
 import { formatKoreanDate } from '@/utils/date';
 import InvalidThumbnail from '@/ui/invalid-thumbnail';
 
+const containerStyles = 'pl-4 flex flex-col gap-2 border-y-[1px]';
+const itemStyles = 'py-3 border-b-[1px] last:border-b-0';
+const beforePseudoElementStyles =
+  'before:content-[attr(data-before)] before:absolute before:-translate-y-8 before:text-neutral-500';
+
 type Props = {
   params: { id: string };
 };
@@ -62,7 +67,7 @@ export default async function BookDetail({ params }: Props) {
         <button>편집</button>
       </HeaderLayout>
 
-      <section className="min-h-screen pb-10 flex flex-col gap-12 bg-zinc-100 *:bg-white">
+      <section className="min-h-screen flex flex-col gap-12 bg-zinc-100 *:bg-white">
         <div>
           <h3 className="pt-2 pb-4 text-xl font-semibold text-center">{title}</h3>
           <div className="px-6 py-2 flex justify-between">
@@ -77,32 +82,29 @@ export default async function BookDetail({ params }: Props) {
               <span>{isbn.split(' ')[1]}</span>
             </div>
           </div>
-          <div className="pl-4 flex flex-col gap-2 border-y-[1px]">
+          <div className={containerStyles}>
             {basicInfoItems.map((item, index) => (
-              <p key={index} className="py-3 border-b-[1px] last:border-b-0">
+              <p key={index} className={itemStyles}>
                 {item}
               </p>
             ))}
           </div>
         </div>
 
-        <div className="pl-4 flex flex-col gap-2 border-y-[1px]">
-          <p className="py-3 border-b-[1px] last:border-b-0">별점: {rating}</p>
-          {review && <p className="py-3 border-b-[1px] last:border-b-0">한 줄 평: {review}</p>}
+        <div className={containerStyles}>
+          <p className={itemStyles}>별점: {rating}</p>
+          {review && <p className={itemStyles}>한 줄 평: {review}</p>}
         </div>
 
-        <div
-          data-before="등록일"
-          className="before:content-[attr(data-before)] before:absolute before:-translate-y-8 before:text-neutral-500 pl-4 flex flex-col gap-2 border-y-[1px]"
-        >
-          <p className="py-3 border-b-[1px] last:border-b-0">{formatKoreanDate(created_at)}</p>
+        <div data-before="등록일" className={`${beforePseudoElementStyles} ${containerStyles}`}>
+          <p className={itemStyles}>{formatKoreanDate(created_at)}</p>
         </div>
 
         <div
           data-before="도서 정보는 Daum에서 제공합니다."
-          className="before:content-[attr(data-before)] before:absolute before:-translate-y-8 before:text-neutral-500 pl-4 flex flex-col gap-2 border-y-[1px]"
+          className={`${beforePseudoElementStyles} ${containerStyles}`}
         >
-          <p className="py-3 border-b-[1px] last:border-b-0">다음 검색에서 보기</p>
+          <p className={itemStyles}>다음 검색에서 보기</p>
         </div>
       </section>
     </>

--- a/app/books/[id]/page.tsx
+++ b/app/books/[id]/page.tsx
@@ -51,7 +51,7 @@ export default async function BookDetail({ params }: Props) {
     `${authorNames.join(', ')} 지음`,
     translatorNames.length > 0 ? `${translatorNames.join(', ')} 옮김` : null,
     publisher,
-  ];
+  ].filter(Boolean); // null 또는 빈 문자열 등을 제거하여 필요한 요소만 포함
 
   return (
     <>
@@ -79,14 +79,11 @@ export default async function BookDetail({ params }: Props) {
             </div>
           </div>
           <div className="pl-4 flex flex-col gap-2 border-y-[1px]">
-            {basicInfoItems.map(
-              (item, index) =>
-                item && (
-                  <p key={index} className="py-3 border-b-[1px] last:border-b-0">
-                    {item}
-                  </p>
-                ),
-            )}
+            {basicInfoItems.map((item, index) => (
+              <p key={index} className="py-3 border-b-[1px] last:border-b-0">
+                {item}
+              </p>
+            ))}
           </div>
         </div>
 

--- a/app/books/[id]/page.tsx
+++ b/app/books/[id]/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { notFound } from 'next/navigation';
+import { StarIcon } from '@heroicons/react/24/outline';
+import { StarIcon as SolidStarIcon } from '@heroicons/react/24/solid';
 import db from '@/lib/db';
 import HeaderLayout from '@/layout/header';
 import { getImageSize } from '@/utils/image';
@@ -11,6 +13,21 @@ const containerStyles = 'pl-4 flex flex-col gap-2 border-y-[1px]';
 const itemStyles = 'py-3 border-b-[1px] last:border-b-0';
 const beforePseudoElementStyles =
   'before:content-[attr(data-before)] before:absolute before:-translate-y-8 before:text-neutral-500';
+
+const MAX_RATING = 5;
+const starIconStyles = 'size-5 text-sky-600';
+
+function StarRating(rating: number) {
+  const stars = Array.from({ length: MAX_RATING }, (_, index) => {
+    return index < rating ? (
+      <SolidStarIcon key={index} className={starIconStyles} />
+    ) : (
+      <StarIcon key={index} className={starIconStyles} />
+    );
+  });
+
+  return <>{stars}</>;
+}
 
 type Props = {
   params: { id: string };
@@ -93,7 +110,7 @@ export default async function BookDetail({ params }: Props) {
         </div>
 
         <div className={containerStyles}>
-          <p className={itemStyles}>별점: {rating}</p>
+          <p className={`flex ${itemStyles}`}>{StarRating(rating)}</p>
           {review && <p className={itemStyles}>한 줄 평: {review}</p>}
         </div>
 

--- a/app/books/[id]/page.tsx
+++ b/app/books/[id]/page.tsx
@@ -41,12 +41,12 @@ async function getBook(id: number) {
     },
     include: {
       authors: {
-        include: {
+        select: {
           author: true,
         },
       },
       translators: {
-        include: {
+        select: {
           translator: true,
         },
       },

--- a/app/books/[id]/page.tsx
+++ b/app/books/[id]/page.tsx
@@ -10,13 +10,13 @@ import { getImageSize } from '@/utils/image';
 import { formatKoreanDate } from '@/utils/date';
 import InvalidThumbnail from '@/ui/invalid-thumbnail';
 
-const containerStyles = 'pl-4 flex flex-col gap-2 border-y-[1px]';
-const itemStyles = 'py-3 border-b-[1px] last:border-b-0';
+const containerStyles = 'pl-4 flex flex-col gap-2 border-y-[1px] dark:border-neutral-700';
+const itemStyles = 'py-3 border-b-[1px] last:border-b-0 dark:border-neutral-700';
 const beforePseudoElementStyles =
   'before:content-[attr(data-before)] before:absolute before:-translate-y-8 before:text-neutral-500';
 
 const MAX_RATING = 5;
-const starIconStyles = 'size-5 text-sky-600';
+const starIconStyles = 'size-5 text-sky-600 dark:text-blue-500';
 
 function StarRating(rating: number) {
   const stars = Array.from({ length: MAX_RATING }, (_, index) => {
@@ -86,19 +86,28 @@ export default async function BookDetail({ params }: Props) {
         <button>편집</button>
       </HeaderLayout>
 
-      <section className="min-h-screen flex flex-col gap-12 bg-zinc-100 *:bg-white">
+      <section className="min-h-screen flex flex-col gap-12 bg-zinc-100 dark:bg-zinc-900 *:bg-white *:dark:bg-zinc-800">
         <div>
-          <h3 className="pt-2 pb-4 text-xl font-semibold text-center">{title}</h3>
-          <div className="px-6 py-2 flex justify-between">
-            {width && height ? (
-              <Image src={thumbnail} alt={title} className="border shadow-xl" width={width} height={height} priority />
-            ) : (
-              <InvalidThumbnail />
-            )}
-            <div className="flex flex-col justify-end items-end *:text-neutral-500">
-              <span>{formatKoreanDate(datetime)}</span>
-              <span>{price.toLocaleString('ko-KR')}원</span>
-              <span>{isbn.split(' ')[1]}</span>
+          <div className="dark:bg-zinc-900">
+            <h3 className="pt-2 pb-4 text-xl font-semibold text-center">{title}</h3>
+            <div className="px-6 py-2 flex justify-between">
+              {width && height ? (
+                <Image
+                  src={thumbnail}
+                  alt={title}
+                  className="border shadow-xl"
+                  width={width}
+                  height={height}
+                  priority
+                />
+              ) : (
+                <InvalidThumbnail />
+              )}
+              <div className="flex flex-col justify-end items-end *:text-neutral-500">
+                <span>{formatKoreanDate(datetime)}</span>
+                <span>{price.toLocaleString('ko-KR')}원</span>
+                <span>{isbn.split(' ')[1]}</span>
+              </div>
             </div>
           </div>
           <div className={containerStyles}>
@@ -122,9 +131,9 @@ export default async function BookDetail({ params }: Props) {
 
         <div
           data-before="도서 정보는 Daum에서 제공합니다."
-          className={`${beforePseudoElementStyles} ${containerStyles} hover:bg-zinc-200`}
+          className={`${beforePseudoElementStyles} ${containerStyles} hover:bg-zinc-200 dark:hover:bg-neutral-600`}
         >
-          <Link href={url} className="text-neutral-900">
+          <Link href={url} className="text-neutral-900 dark:text-gray-100">
             <p className={itemStyles}>Daum 검색에서 보기</p>
           </Link>
         </div>

--- a/app/books/[id]/page.tsx
+++ b/app/books/[id]/page.tsx
@@ -4,6 +4,7 @@ import db from '@/lib/db';
 import HeaderLayout from '@/layout/header';
 import { getImageSize } from '@/utils/image';
 import { formatKoreanDate } from '@/utils/date';
+import InvalidThumbnail from '@/ui/invalid-thumbnail';
 
 type Props = {
   params: { id: string };
@@ -68,9 +69,7 @@ export default async function BookDetail({ params }: Props) {
             {width && height ? (
               <Image src={thumbnail} alt={title} className="border shadow-xl" width={width} height={height} priority />
             ) : (
-              <span className="w-[120px] h-[174px] flex items-center text-center bg-gray-400">
-                Invalid thumbnail URL
-              </span>
+              <InvalidThumbnail />
             )}
             <div className="flex flex-col justify-end items-end *:text-neutral-500">
               <span>{formatKoreanDate(datetime)}</span>

--- a/app/books/[id]/page.tsx
+++ b/app/books/[id]/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import Image from 'next/image';
 import { notFound } from 'next/navigation';
 import db from '@/lib/db';
@@ -102,9 +103,11 @@ export default async function BookDetail({ params }: Props) {
 
         <div
           data-before="도서 정보는 Daum에서 제공합니다."
-          className={`${beforePseudoElementStyles} ${containerStyles}`}
+          className={`${beforePseudoElementStyles} ${containerStyles} hover:bg-zinc-200`}
         >
-          <p className={itemStyles}>다음 검색에서 보기</p>
+          <Link href={url} className="text-neutral-900">
+            <p className={itemStyles}>Daum 검색에서 보기</p>
+          </Link>
         </div>
       </section>
     </>

--- a/app/books/[id]/page.tsx
+++ b/app/books/[id]/page.tsx
@@ -5,6 +5,7 @@ import { StarIcon } from '@heroicons/react/24/outline';
 import { StarIcon as SolidStarIcon } from '@heroicons/react/24/solid';
 import db from '@/lib/db';
 import HeaderLayout from '@/layout/header';
+import EditableReview from '@/ui/book/editable-review';
 import { getImageSize } from '@/utils/image';
 import { formatKoreanDate } from '@/utils/date';
 import InvalidThumbnail from '@/ui/invalid-thumbnail';
@@ -81,7 +82,7 @@ export default async function BookDetail({ params }: Props) {
     <>
       {/* //TODO: Header 버튼 스타일링 및 액션 입히기 */}
       <HeaderLayout>
-        <span>뒤로</span>
+        <button>뒤로</button>
         <button>편집</button>
       </HeaderLayout>
 
@@ -109,9 +110,10 @@ export default async function BookDetail({ params }: Props) {
           </div>
         </div>
 
+        {/* // TODO: rating과 review 사용자 입력값 DB에 업데이트 */}
         <div className={containerStyles}>
           <p className={`flex ${itemStyles}`}>{StarRating(rating)}</p>
-          {review && <p className={itemStyles}>한 줄 평: {review}</p>}
+          <div className={itemStyles}>{review ? `한 줄 평: ${review}` : <EditableReview />}</div>
         </div>
 
         <div data-before="등록일" className={`${beforePseudoElementStyles} ${containerStyles}`}>
@@ -126,6 +128,8 @@ export default async function BookDetail({ params }: Props) {
             <p className={itemStyles}>Daum 검색에서 보기</p>
           </Link>
         </div>
+
+        {/* // TODO: '책 삭제' text button 마크업 및 DB 연동 */}
       </section>
     </>
   );

--- a/app/books/[id]/page.tsx
+++ b/app/books/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import db from '@/lib/db';
 import HeaderLayout from '@/layout/header';
 import { getImageSize } from '@/utils/image';
+import { formatKoreanDate } from '@/utils/date';
 
 type Props = {
   params: { id: string };
@@ -72,7 +73,7 @@ export default async function BookDetail({ params }: Props) {
               </span>
             )}
             <div className="flex flex-col justify-end items-end *:text-neutral-500">
-              <span>{datetime.toLocaleString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' })}</span>
+              <span>{formatKoreanDate(datetime)}</span>
               <span>{price.toLocaleString('ko-KR')}원</span>
               <span>{isbn.split(' ')[1]}</span>
             </div>
@@ -98,9 +99,7 @@ export default async function BookDetail({ params }: Props) {
           data-before="등록일"
           className="before:content-[attr(data-before)] before:absolute before:-translate-y-8 before:text-neutral-500 pl-4 flex flex-col gap-2 border-y-[1px]"
         >
-          <p className="py-3 border-b-[1px] last:border-b-0">
-            {created_at.toLocaleString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' })}
-          </p>
+          <p className="py-3 border-b-[1px] last:border-b-0">{formatKoreanDate(created_at)}</p>
         </div>
 
         <div

--- a/app/layout/header.tsx
+++ b/app/layout/header.tsx
@@ -4,7 +4,7 @@ type Props = {
 
 export default function HeaderLayout({ children }: Props) {
   return (
-    <header className="p-4 flex justify-between items-center bg-gray-50 dark:bg-zinc-700 border-b border-gray-200 dark:border-zinc-600">
+    <header className="p-4 flex justify-between items-center bg-gray-50 dark:bg-zinc-700 border-b border-gray-200 dark:border-zinc-600 *:dark:text-blue-500">
       {children}
     </header>
   );

--- a/app/layout/header.tsx
+++ b/app/layout/header.tsx
@@ -1,0 +1,11 @@
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function HeaderLayout({ children }: Props) {
+  return (
+    <header className="p-4 flex justify-between items-center bg-gray-50 dark:bg-zinc-700 border-b border-gray-200 dark:border-zinc-600">
+      {children}
+    </header>
+  );
+}

--- a/app/ui/book/editable-review.tsx
+++ b/app/ui/book/editable-review.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useState } from 'react';
+
+function EditableReview() {
+  const [review, setReview] = useState('');
+  const [isEditing, setIsEditing] = useState(false);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setReview(event.target.value);
+  };
+
+  const handleClick = () => {
+    setIsEditing(true);
+  };
+
+  const handleBlur = () => {
+    setIsEditing(false);
+  };
+
+  return (
+    <>
+      {isEditing ? (
+        <input
+          type="text"
+          value={review}
+          onChange={handleChange}
+          onBlur={handleBlur}
+          autoFocus
+          placeholder="한 줄 평을 작성해 보세요."
+          className="w-[96%] text-zinc-600 border-b-[1px] border-gray-300 focus:outline-none"
+        />
+      ) : (
+        <span onClick={handleClick}>
+          {review ? `한 줄 평: ${review}` : <span className="text-zinc-400">한 줄 평을 작성해 보세요.</span>}
+        </span>
+      )}
+    </>
+  );
+}
+
+export default EditableReview;

--- a/app/ui/bookshelf/book-thumbnail.tsx
+++ b/app/ui/bookshelf/book-thumbnail.tsx
@@ -33,7 +33,7 @@ export default function BookThumbnail({ id, thumbnail, title }: Props) {
   }
 
   return currentMode === 'view' ? (
-    <Link href={`/mine/${id}`} className="cursor-pointer">
+    <Link href={`/books/${id}`} className="cursor-pointer">
       <Image src={thumbnail} alt={title} className="shadow-lg" width={width} height={height} />
     </Link>
   ) : (

--- a/app/ui/bookshelf/book-thumbnail.tsx
+++ b/app/ui/bookshelf/book-thumbnail.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { CheckCircleIcon } from '@heroicons/react/24/outline';
 import { useBookThumbnail } from '@/utils/hooks/useBookThumbnail';
+import InvalidThumbnail from '@/ui//invalid-thumbnail';
 
 // thumbnail url 예시: https://search1.kakaocdn.net/thumb/R120x174.q85/?fname=http%3A%2F%2Ft1.daumcdn.net%2Flbook%2Fimage%2F1467038
 // 위의 예시에서 /thumb/R120x174 처럼 url path에 이미지의 width, height 정보가 들어있음.
@@ -29,7 +30,7 @@ export default function BookThumbnail({ id, thumbnail, title }: Props) {
   const { isSelected, handleClick, currentMode } = useBookThumbnail(id, thumbnail);
 
   if (!width || !height) {
-    return <span className="w-[120px] h-[174px] flex items-center text-center bg-gray-400">Invalid thumbnail URL</span>;
+    return <InvalidThumbnail />;
   }
 
   return currentMode === 'view' ? (

--- a/app/ui/bookshelf/header.tsx
+++ b/app/ui/bookshelf/header.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { usePathname, useSearchParams, useRouter } from 'next/navigation';
 import { PlusIcon, Bars3BottomLeftIcon } from '@heroicons/react/24/outline';
+import HeaderLayout from '@/layout/header';
 import { DeleteBooks } from '@/ui/bookshelf/buttons';
 import { SELECTED_ITEMS_KEY } from '@/constants';
 
@@ -10,11 +11,11 @@ type Props = { title: string };
 
 export default function Header({ title }: Props) {
   return (
-    <header className="p-4 flex justify-between items-center bg-gray-50 dark:bg-zinc-700 border-b border-gray-200 dark:border-zinc-600">
+    <HeaderLayout>
       <ActionButtons />
       <h2 className="text-2xl font-medium dark:text-neutral-200">{title}</h2>
       <ToggleButtons />
-    </header>
+    </HeaderLayout>
   );
 }
 

--- a/app/ui/invalid-thumbnail.tsx
+++ b/app/ui/invalid-thumbnail.tsx
@@ -1,0 +1,3 @@
+export default function InvalidThumbnail() {
+  return <span className="w-[120px] h-[174px] flex items-center text-center bg-gray-400">Invalid thumbnail URL</span>;
+}

--- a/app/utils/date.ts
+++ b/app/utils/date.ts
@@ -1,0 +1,6 @@
+/**
+ * @returns {string} 연월일 형식으로 포맷된 문자열 (예: '2024년 7월 18일')
+ */
+export function formatKoreanDate(date: Date): string {
+  return date.toLocaleString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' });
+}

--- a/app/utils/image.ts
+++ b/app/utils/image.ts
@@ -1,0 +1,16 @@
+// thumbnail url 예시: https://search1.kakaocdn.net/thumb/R120x174.q85/?fname=http%3A%2F%2Ft1.daumcdn.net%2Flbook%2Fimage%2F1467038
+// 위의 예시에서 /thumb/R120x174 처럼 url path에 이미지의 width, height 정보가 들어있음.
+// 이를 추출하기 위한 헬퍼 함수
+export function getImageSize(url: string) {
+  const regex = /\/thumb\/R(\d+)x(\d+)/;
+  const match = url.match(regex);
+
+  if (match) {
+    return {
+      width: Number(match[1]),
+      height: Number(match[2]),
+    };
+  }
+
+  return { width: null, height: null };
+}

--- a/prisma/migrations/20240718053240_update_book_adding_created_and_updated_dates/migration.sql
+++ b/prisma/migrations/20240718053240_update_book_adding_created_and_updated_dates/migration.sql
@@ -1,0 +1,30 @@
+/*
+  Warnings:
+
+  - Added the required column `updated_at` to the `Book` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Book" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "title" TEXT NOT NULL,
+    "datetime" DATETIME NOT NULL,
+    "price" INTEGER NOT NULL,
+    "publisher" TEXT NOT NULL,
+    "thumbnail" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "isbn" TEXT NOT NULL,
+    "rating" INTEGER NOT NULL DEFAULT 0,
+    "review" TEXT,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME NOT NULL,
+    "bookshelfId" INTEGER NOT NULL,
+    CONSTRAINT "Book_bookshelfId_fkey" FOREIGN KEY ("bookshelfId") REFERENCES "Bookshelf" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_Book" ("bookshelfId", "datetime", "id", "isbn", "price", "publisher", "rating", "review", "thumbnail", "title", "url") SELECT "bookshelfId", "datetime", "id", "isbn", "price", "publisher", "rating", "review", "thumbnail", "title", "url" FROM "Book";
+DROP TABLE "Book";
+ALTER TABLE "new_Book" RENAME TO "Book";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,6 +46,8 @@ model Book {
   isbn        String
   rating      Int              @default(0)
   review      String? // 사용자가 남기는 한 줄 서평 
+  created_at  DateTime   @default(now())
+  updated_at  DateTime   @updatedAt
   Bookshelf   Bookshelf        @relation(fields: [bookshelfId], references: [id])
   bookshelfId Int
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,6 +76,6 @@ model TranslatorBook {
   id           Int        @id @default(autoincrement())
   book         Book       @relation(fields: [bookId], references: [id], onDelete: Cascade)
   bookId       Int
-  Translator   Translator @relation(fields: [translatorId], references: [id], onDelete: Cascade)
+  translator   Translator @relation(fields: [translatorId], references: [id], onDelete: Cascade)
   translatorId Int
 }


### PR DESCRIPTION
관련 티켓 #15

## 주요 변경 사항 
- 책장 목록에서 섬네일 클릭시 상세 페이지(`/books/{id}`)로 이동 
- 책 상세 페이지 마크업 및 스타일링 
- [DB] [Book 모델에 created_at, updated_at 필드 추가](https://github.com/Ah-ae/what-are-you-reading/commit/6aa8b63c4e41d4de7c5971537e84cb0d836a7a2e)

### 스크린샷
<img width="480" alt="스크린샷 2024-07-18 오후 9 24 40" src="https://github.com/user-attachments/assets/a0e748bf-600d-4555-8e99-33030ce74284">
<img width="480" alt="스크린샷 2024-07-18 오후 9 25 08" src="https://github.com/user-attachments/assets/390ff96c-e6a1-41c1-abc7-bdbcd914d53e">

