### PR TITLE
fix: 회원가입 시 자동으로 bookshelf 생성 로직 추가

### DIFF
--- a/app/(auth)/signup/actions.ts
+++ b/app/(auth)/signup/actions.ts
@@ -89,6 +89,13 @@ export async function createAccount(prevState: any, formData: FormData) {
       },
     });
 
+    // Create a bookshelf for the new user
+    await db.bookshelf.create({
+      data: {
+        ownerId: user.id,
+      },
+    });
+
     await login(user.id);
     redirect('/mine');
   } else {


### PR DESCRIPTION
closes #35

DB에 `bookshelf`가 생성되지 않았기 때문에 `fetchBooks` 함수에서 다음의 에러가 발생했던 것 

> Database Error: Bookshelf not found for user(id: 4)