### PR TITLE
update: `/books` 하위 페이지에서 사용하는 Header 레이아웃 등 구현 

### DIFF
--- a/app/(bookshelf)/layout.tsx
+++ b/app/(bookshelf)/layout.tsx
@@ -3,7 +3,7 @@ import BottomNav from '@/ui/nav/bottom-nav';
 export default function SharedLayout({ children }: { children: React.ReactNode }) {
   return (
     <>
-      <section className="pb-[64px]">{children}</section>
+      <section className="pt-[60px] pb-[64px]">{children}</section>
       <BottomNav />
     </>
   );

--- a/app/books/[id]/page.tsx
+++ b/app/books/[id]/page.tsx
@@ -6,6 +6,7 @@ import HeaderLayout from '@/layout/header';
 import EditableReview from '@/ui/books/editable-review';
 import InvalidThumbnail from '@/ui/invalid-thumbnail';
 import StarRating from '@/ui/books/star-rating';
+import BackButton from '@/ui/back-button';
 import { getImageSize } from '@/utils/image';
 import { formatKoreanDate } from '@/utils/date';
 
@@ -64,9 +65,8 @@ export default async function BookDetail({ params }: Props) {
 
   return (
     <>
-      {/* //TODO: Header 버튼 스타일링 및 액션 입히기 */}
       <HeaderLayout>
-        <button>뒤로</button>
+        <BackButton />
       </HeaderLayout>
 
       <section className="min-h-screen flex flex-col gap-12 bg-zinc-100 dark:bg-zinc-900 *:bg-white *:dark:bg-zinc-800">

--- a/app/books/[id]/page.tsx
+++ b/app/books/[id]/page.tsx
@@ -69,7 +69,8 @@ export default async function BookDetail({ params }: Props) {
         <BackButton />
       </HeaderLayout>
 
-      <section className="flex flex-col gap-12 bg-zinc-100 dark:bg-zinc-900 *:bg-white *:dark:bg-zinc-800">
+      {/* Note: `pt-[60px]` - header height만큼 공간 확보 */}
+      <section className="pt-[60px] flex flex-col gap-12 bg-zinc-100 dark:bg-zinc-900 *:bg-white *:dark:bg-zinc-800">
         <div>
           <div className="dark:bg-zinc-900">
             <h3 className="pt-2 pb-4 text-xl font-semibold text-center">{title}</h3>

--- a/app/books/[id]/page.tsx
+++ b/app/books/[id]/page.tsx
@@ -69,7 +69,7 @@ export default async function BookDetail({ params }: Props) {
         <BackButton />
       </HeaderLayout>
 
-      <section className="min-h-screen flex flex-col gap-12 bg-zinc-100 dark:bg-zinc-900 *:bg-white *:dark:bg-zinc-800">
+      <section className="flex flex-col gap-12 bg-zinc-100 dark:bg-zinc-900 *:bg-white *:dark:bg-zinc-800">
         <div>
           <div className="dark:bg-zinc-900">
             <h3 className="pt-2 pb-4 text-xl font-semibold text-center">{title}</h3>

--- a/app/books/add/layout.tsx
+++ b/app/books/add/layout.tsx
@@ -1,0 +1,5 @@
+import StoreProvider from '@/store/store-provider';
+
+export default function AddBooksLayout({ children }: { children: React.ReactNode }) {
+  return <StoreProvider>{children}</StoreProvider>;
+}

--- a/app/books/add/list/page.tsx
+++ b/app/books/add/list/page.tsx
@@ -30,7 +30,8 @@ export default async function List({
         <BackButton>검색 목록</BackButton>
       </HeaderLayout>
 
-      <section className="p-4">
+      {/* Note: `pt-14` - header height만큼 공간 확보 + page section의 자체 패딩 */}
+      <section className="pt-16 px-4 pb-4">
         {ownedBookList.length > 0 ? (
           <>
             <p className="text-center">책을 선택하면 현재 책장에 바로 배치됩니다.</p>

--- a/app/books/add/list/page.tsx
+++ b/app/books/add/list/page.tsx
@@ -1,5 +1,6 @@
 import HeaderLayout from '@/layout/header';
 import BookList from '@/ui/books/cards';
+import BackButton from '@/ui/back-button';
 import { searchBooks, checkOwnedBooks } from '@/books/add/list/actions';
 import getSession from '@/lib/session';
 
@@ -25,9 +26,8 @@ export default async function List({
 
   return (
     <>
-      {/* //TODO: Header 버튼 스타일링 및 액션 입히기 */}
       <HeaderLayout>
-        <button>검색 목록</button>
+        <BackButton>검색 목록</BackButton>
       </HeaderLayout>
 
       <section className="p-4">

--- a/app/books/add/page.tsx
+++ b/app/books/add/page.tsx
@@ -32,7 +32,8 @@ export default function AddBook({
         <DeleteKeywordsButton />
       </HeaderLayout>
 
-      <section className="p-4">
+      {/* Note: `pt-14` - header height만큼 공간 확보 + page section의 자체 패딩 */}
+      <section className="pt-20 px-4 pb-4">
         <SearchForm query={query} target={target} />
         <Tab tabs={tabs} />
         <KeywordList />

--- a/app/books/add/page.tsx
+++ b/app/books/add/page.tsx
@@ -1,5 +1,7 @@
 import HeaderLayout from '@/layout/header';
 import BackButton from '@/ui/back-button';
+import DeleteKeywordsButton from '@/ui/books/delete-keywords-button';
+import KeywordList from '@/ui/books/keyword-list';
 import SearchForm from '@/ui/books/search-form';
 import Tab from '@/ui/books/tab';
 
@@ -27,12 +29,13 @@ export default function AddBook({
         <div>
           <h2 className="text-xl font-medium dark:text-neutral-200">검색 목록</h2>
         </div>
-        <button>목록 삭제</button>
+        <DeleteKeywordsButton />
       </HeaderLayout>
 
       <section className="p-4">
         <SearchForm query={query} target={target} />
         <Tab tabs={tabs} />
+        <KeywordList />
       </section>
     </>
   );

--- a/app/books/add/page.tsx
+++ b/app/books/add/page.tsx
@@ -1,4 +1,5 @@
 import HeaderLayout from '@/layout/header';
+import BackButton from '@/ui/back-button';
 import SearchForm from '@/ui/books/search-form';
 import Tab from '@/ui/books/tab';
 
@@ -21,9 +22,8 @@ export default function AddBook({
 
   return (
     <>
-      {/* //TODO: Header 버튼 스타일링 및 액션 입히기 */}
       <HeaderLayout>
-        <button>뒤로</button>
+        <BackButton />
         <div>
           <h2 className="text-xl font-medium dark:text-neutral-200">검색 목록</h2>
         </div>

--- a/app/layout/header.tsx
+++ b/app/layout/header.tsx
@@ -4,7 +4,7 @@ type Props = {
 
 export default function HeaderLayout({ children }: Props) {
   return (
-    <header className="p-4 flex justify-between items-center bg-gray-50 dark:bg-zinc-700 border-b border-gray-200 dark:border-zinc-600 *:dark:text-blue-500">
+    <header className="sticky top-0 z-10 p-4 flex justify-between items-center bg-gray-50 dark:bg-zinc-700 border-b border-gray-200 dark:border-zinc-600 *:dark:text-blue-500">
       {children}
     </header>
   );

--- a/app/layout/header.tsx
+++ b/app/layout/header.tsx
@@ -1,10 +1,14 @@
+import { MAX_WIDTH } from '@/constants/style';
+
 type Props = {
   children: React.ReactNode;
 };
 
 export default function HeaderLayout({ children }: Props) {
   return (
-    <header className="sticky top-0 z-10 p-4 flex justify-between items-center bg-gray-50 dark:bg-zinc-700 border-b border-gray-200 dark:border-zinc-600 *:dark:text-blue-500">
+    <header
+      className={`w-full fixed top-0 left-1/2 transform -translate-x-1/2 ${MAX_WIDTH} z-10 p-4 flex justify-between items-center bg-gray-50 dark:bg-zinc-700 border-b border-gray-200 dark:border-zinc-600 *:dark:text-blue-500`}
+    >
       {children}
     </header>
   );

--- a/app/store/atoms.ts
+++ b/app/store/atoms.ts
@@ -3,3 +3,4 @@ import { atomWithReset } from 'jotai/utils';
 
 export const currentModeAtom = atom<'view' | 'edit'>('view');
 export const selectedItemsAtom = atomWithReset<number[]>([]); // 삭제할 책 id를 담는 배열
+export const keywordListAtom = atomWithReset<string[]>([]);

--- a/app/ui/back-button.tsx
+++ b/app/ui/back-button.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { ChevronLeftIcon } from '@heroicons/react/24/outline';
+
+type Props = {
+  children?: React.ReactNode;
+};
+
+export default function BackButton({ children = '뒤로' }: Props) {
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.back();
+  };
+
+  return (
+    <button onClick={handleClick} className="w-24 flex gap-1 text-main-theme-color dark:text-blue-500">
+      <ChevronLeftIcon className="size-6 stroke-2" />
+      <span>{children}</span>
+    </button>
+  );
+}

--- a/app/ui/books/delete-keywords-button.tsx
+++ b/app/ui/books/delete-keywords-button.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useResetAtom } from 'jotai/utils';
+import { keywordListAtom } from '@/store/atoms';
+
+export default function DeleteKeywordsButton() {
+  const resetKeywordList = useResetAtom(keywordListAtom);
+
+  const handleDelete = () => {
+    resetKeywordList();
+  };
+
+  return (
+    <button onClick={handleDelete} className="text-main-theme-color dark:text-blue-500">
+      목록 삭제
+    </button>
+  );
+}

--- a/app/ui/books/keyword-list.tsx
+++ b/app/ui/books/keyword-list.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useAtomValue } from 'jotai';
+import { keywordListAtom } from '@/store/atoms';
+
+export default function KeywordList() {
+  const keywords = useAtomValue(keywordListAtom);
+
+  return keywords.length > 0 ? (
+    <ul className="py-3">
+      {keywords.map((keyword, index) => (
+        <li key={index} className="py-2 first:border-t-[1px] border-b-[1px] dark:border-neutral-700">
+          {keyword}
+        </li>
+      ))}
+    </ul>
+  ) : null;
+}

--- a/app/ui/books/search-form.tsx
+++ b/app/ui/books/search-form.tsx
@@ -21,7 +21,12 @@ export default function SearchForm({ query, target }: Props) {
     const formattedParams = new URLSearchParams(params).toString();
 
     router.push(`/books/add/list?${formattedParams}`);
-    setKeywordList((prev) => [...prev, query]);
+    setKeywordList((prev) => {
+      if (!prev.includes(query)) {
+        return [...prev, query];
+      }
+      return prev;
+    });
   };
 
   return (

--- a/app/ui/books/search-form.tsx
+++ b/app/ui/books/search-form.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { useSetAtom } from 'jotai';
 import Search from '@/ui/search';
+import { keywordListAtom } from '@/store/atoms';
 
 type Props = {
   query: string;
@@ -10,6 +12,7 @@ type Props = {
 
 export default function SearchForm({ query, target }: Props) {
   const router = useRouter();
+  const setKeywordList = useSetAtom(keywordListAtom);
 
   const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -18,6 +21,7 @@ export default function SearchForm({ query, target }: Props) {
     const formattedParams = new URLSearchParams(params).toString();
 
     router.push(`/books/add/list?${formattedParams}`);
+    setKeywordList((prev) => [...prev, query]);
   };
 
   return (

--- a/app/ui/bookshelf/buttons.tsx
+++ b/app/ui/bookshelf/buttons.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import Link from 'next/link';
 import { useResetAtom } from 'jotai/utils';
 import clsx from 'clsx';
 import { PlusIcon, TrashIcon, Bars3BottomLeftIcon } from '@heroicons/react/24/outline';
@@ -30,6 +31,22 @@ export function DeleteBooks({ ids }: { ids: number[] }) {
           'text-neutral-400': disabled,
         })}
       />
+    </button>
+  );
+}
+
+export function AddBook() {
+  return (
+    <Link href="/books/add">
+      <PlusIcon className="size-6 stroke-2 text-main-theme-color dark:text-blue-500" />
+    </Link>
+  );
+}
+
+export function RearrangeBooks() {
+  return (
+    <button>
+      <Bars3BottomLeftIcon className="size-6 font-bold text-main-theme-color dark:text-blue-500" />
     </button>
   );
 }

--- a/app/ui/bookshelf/header.tsx
+++ b/app/ui/bookshelf/header.tsx
@@ -49,7 +49,7 @@ function ActionButtons() {
     <div className="w-[28px] flex gap-3">
       {currentMode === 'view' ? (
         <Link href="/books/add">
-          <PlusIcon className="size-6 font-bold text-main-theme-color dark:text-blue-500" />
+          <PlusIcon className="size-6 stroke-2 text-main-theme-color dark:text-blue-500" />
         </Link>
       ) : (
         <>

--- a/app/ui/bookshelf/header.tsx
+++ b/app/ui/bookshelf/header.tsx
@@ -1,11 +1,9 @@
 'use client';
 
-import Link from 'next/link';
 import { useAtom, useAtomValue } from 'jotai';
 import { useResetAtom } from 'jotai/utils';
-import { PlusIcon, Bars3BottomLeftIcon } from '@heroicons/react/24/outline';
 import HeaderLayout from '@/layout/header';
-import { DeleteBooks } from '@/ui/bookshelf/buttons';
+import { AddBook, DeleteBooks, RearrangeBooks } from '@/ui/bookshelf/buttons';
 import { currentModeAtom, selectedItemsAtom } from '@/store/atoms';
 
 type Props = { title: string };
@@ -48,15 +46,11 @@ function ActionButtons() {
   return (
     <div className="w-[28px] flex gap-3">
       {currentMode === 'view' ? (
-        <Link href="/books/add">
-          <PlusIcon className="size-6 stroke-2 text-main-theme-color dark:text-blue-500" />
-        </Link>
+        <AddBook />
       ) : (
         <>
           <DeleteBooks ids={selectedItems} />
-          <button>
-            <Bars3BottomLeftIcon className="size-6 font-bold text-main-theme-color dark:text-blue-500" />
-          </button>
+          <RearrangeBooks />
         </>
       )}
     </div>

--- a/app/ui/search.tsx
+++ b/app/ui/search.tsx
@@ -20,7 +20,7 @@ function Search({ wrapperClassName = '', ...args }: Props & InputHTMLAttributes<
     } else {
       params.delete('query');
     }
-    replace(`${pathname}?${params.toString()}`);
+    replace(`${pathname}?${params.toString()}`, { scroll: false });
   };
 
   return (


### PR DESCRIPTION
closes #25 

## 주요 변경 사항 
- `/books` 하위 페이지에서 사용하는 Header 레이아웃 설정: `fixed` 등 
- Header의 `BackButton` 구현 
- 검색 목록에 한 번 이상 검색한 키워드 목록 노출 및 일괄 삭제 기능 제공 

### 스크린샷 
<img width="480" alt="스크린샷 2024-08-25 오후 1 18 00" src="https://github.com/user-attachments/assets/b2889cae-b579-4d7a-a1e9-3da9b37f63ed">
<img width="480" alt="스크린샷 2024-08-25 오후 1 17 37" src="https://github.com/user-attachments/assets/ad638d1e-0261-4e0d-badc-e4bf150dad29">
