### PR TITLE
fix: 카카오 회원가입 시 자동으로 bookshelf 생성 로직 추가

### DIFF
--- a/app/(auth)/kakao/complete/route.ts
+++ b/app/(auth)/kakao/complete/route.ts
@@ -106,6 +106,13 @@ export async function GET(request: NextRequest) {
     },
   });
 
+  // Create a bookshelf for the new user
+  await db.bookshelf.create({
+    data: {
+      ownerId: newUser.id,
+    },
+  });
+
   await login(newUser.id);
   redirect('/mine');
 }


### PR DESCRIPTION
관련 PR #36 

PR #46에서 회원가입 페이지 및 로직을 삭제했기 때문에 현재로써는 카카오 `/complete` route.ts에서 로그인 전에 책장을 자동으로 생성해줘야 함 