### PR TITLE
fix: 책 상세 페이지에서 min height 값 수정하여 배경색 통일

### DIFF
--- a/app/(bookshelf)/mine/[id]/page.tsx
+++ b/app/(bookshelf)/mine/[id]/page.tsx
@@ -79,7 +79,7 @@ export default async function BookDetail({ params }: Props) {
     <>
       <HeaderLayout />
 
-      <section className="h-full pb-12 flex flex-col gap-12 bg-zinc-100 dark:bg-zinc-900 *:bg-white *:dark:bg-zinc-800 group">
+      <section className="min-h-[calc(100dvh-6rem)] pb-12 flex flex-col gap-12 bg-zinc-100 dark:bg-zinc-900 *:bg-white *:dark:bg-zinc-800 group">
         <div>
           <div className="dark:bg-zinc-900">
             <h3 className="py-2 text-lg font-semibold text-center">{title}</h3>


### PR DESCRIPTION
🔽 수정 전
<img width="400" alt="스크린샷 2024-09-22 오전 10 33 55" src="https://github.com/user-attachments/assets/a7e5e9cd-71ef-42e5-8e37-bf1800a244f2">

🔽 수정 후
<img width="400" alt="스크린샷 2024-09-22 오전 10 34 32" src="https://github.com/user-attachments/assets/c8d3c983-8f08-47f8-b57e-6f6c6d573051">
