### PR TITLE
fix: scroll restoration 복구

### DIFF
--- a/app/ui/bookshelf/book-thumbnail.tsx
+++ b/app/ui/bookshelf/book-thumbnail.tsx
@@ -41,7 +41,6 @@ export default function BookThumbnail({ id, thumbnail, title }: Props) {
         query: { thumbnail, title },
       }}
       className="cursor-pointer"
-      scroll={false}
     >
       <Image
         src={thumbnail}


### PR DESCRIPTION
### 버그 현상 
책 목록 페이지에서 책이 스크롤이 생길만큼 많아졌을 때, 스크롤을 내려 아래쪽에 있는 책을 클릭해 상세 페이지로 이동할 때 스크롤이 제일 위로 올라가는 restoration이 작동할 수 있도록 `scroll={false}` prop 제거 

closes #74 