### PR TITLE
fix: Edge Runtime 미들웨어 에러 수정

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,3 @@
-import getSession from '@/lib/session';
 import { NextRequest, NextResponse } from 'next/server';
 
 interface Routes {
@@ -14,10 +13,12 @@ const publicOnlyUrls: Routes = {
 };
 
 export async function middleware(request: NextRequest) {
-  const session = await getSession();
+  // Edge Runtime에서는 iron-session을 사용할 수 없으므로 (eval 제한), 쿠키 존재 여부로 로그인 상태를 판단합니다.
+  // 실제 세션 검증은 각 페이지의 서버 컴포넌트/액션에서 처리됩니다.
+  const sessionCookie = request.cookies.get('wayr');
   const exists = publicOnlyUrls[request.nextUrl.pathname];
 
-  if (!session.id) {
+  if (!sessionCookie) {
     if (!exists) {
       return NextResponse.redirect(new URL('/', request.url));
     }


### PR DESCRIPTION
## Summary
- 프로덕션 환경에서 `500 MIDDLEWARE_INVOCATION_FAILED` 에러 수정
<img width="1060" height="1100" alt="SCR-20260218-ltys" src="https://github.com/user-attachments/assets/d6f49a3d-1e5a-481f-b500-0e743da4cf18" />

- Edge Runtime에서 `eval()`이 차단되어 iron-session 암호화 코드가 동작하지 않는 문제
- 미들웨어에서 iron-session 대신 쿠키 존재 여부(`request.cookies.get`)로 로그인 상태 판단하도록 변경
- 실제 세션 검증은 기존대로 서버 컴포넌트/액션에서 처리

## Test plan
- [x] `npm run build` 정상 완료
- [x] `npm run start` 후 `curl localhost:3000` → HTTP 200 확인
- [x] Vercel 프리뷰 배포에서 로그인/비로그인 리다이렉트 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)