### PR TITLE
feat: 친구 책장 보기 기능

### DIFF
--- a/app/(bookshelf)/mine/actions.ts
+++ b/app/(bookshelf)/mine/actions.ts
@@ -10,7 +10,9 @@ export async function getBooks(userId: number) {
         ownerId: userId,
       },
       include: {
-        books: true,
+        books: {
+          orderBy: { created_at: 'desc' },
+        },
       },
     });
 

--- a/app/(bookshelf)/settings/friends/page.tsx
+++ b/app/(bookshelf)/settings/friends/page.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+import { UserPlusIcon } from '@heroicons/react/24/outline';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui';
 import HeaderLayout from '@/layout/header';
 import FriendsListTabContent from '@/ui/friends/friends-list-tab-content';
@@ -9,7 +11,15 @@ export default async function FriendsSettings() {
 
   return (
     <>
-      <HeaderLayout backButtonText="설정" title="친구 관리" />
+      <HeaderLayout
+        backButtonText="설정"
+        title="친구 관리"
+        rightItem={
+          <Link href="/friends/add" scroll={false}>
+            <UserPlusIcon className="size-5 stroke-2" />
+          </Link>
+        }
+      />
 
       <div className="p-3 bg-white dark:bg-inherit">
         <Tabs defaultValue="list">

--- a/app/(bookshelf)/yours/[userId]/[id]/page.tsx
+++ b/app/(bookshelf)/yours/[userId]/[id]/page.tsx
@@ -26,11 +26,11 @@ export default async function FriendBookDetail({ params }: Props) {
   const isFriend = await verifyFriendship(userId);
   if (!isFriend) return notFound();
 
-  const isOwner = await verifyBookOwnership(userId, bookId);
-  if (!isOwner) return notFound();
-
-  const book = await getBook(bookId);
-  if (!book) return notFound();
+  const [isOwner, book] = await Promise.all([
+    verifyBookOwnership(userId, bookId),
+    getBook(bookId),
+  ]);
+  if (!isOwner || !book) return notFound();
 
   const { title, thumbnail, datetime, price, authors, translators, publisher, url, isbn, rating, review, created_at } =
     book;

--- a/app/(bookshelf)/yours/[userId]/[id]/page.tsx
+++ b/app/(bookshelf)/yours/[userId]/[id]/page.tsx
@@ -1,0 +1,112 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { notFound } from 'next/navigation';
+import { getBook } from '@/(bookshelf)/mine/[id]/actions';
+import { verifyFriendship, verifyBookOwnership } from '@/(bookshelf)/yours/actions';
+import HeaderLayout from '@/layout/header';
+import InvalidThumbnail from '@/ui/invalid-thumbnail';
+import StarRating from '@/ui/books/star-rating';
+import { getImageSize } from '@/utils/image';
+import { formatKoreanDate } from '@/utils/date';
+import {
+  IMAGE_ASPECT_RATIO,
+  SCALE_FACTOR,
+  containerStyles,
+  itemStyles,
+  beforePseudoElementStyles,
+} from '@/constants/style';
+
+type Props = { params: { userId: string; id: string } };
+
+export default async function FriendBookDetail({ params }: Props) {
+  const userId = Number(params.userId);
+  const bookId = Number(params.id);
+  if (Number.isNaN(userId) || Number.isNaN(bookId)) return notFound();
+
+  const isFriend = await verifyFriendship(userId);
+  if (!isFriend) return notFound();
+
+  const isOwner = await verifyBookOwnership(userId, bookId);
+  if (!isOwner) return notFound();
+
+  const book = await getBook(bookId);
+  if (!book) return notFound();
+
+  const { title, thumbnail, datetime, price, authors, translators, publisher, url, isbn, rating, review, created_at } =
+    book;
+
+  const { width, height } = getImageSize(thumbnail);
+
+  const authorNames = authors.map((author) => author.author.name);
+  const translatorNames = translators.map((translator) => translator.translator.name);
+  const basicInfoItems = [
+    `${authorNames.join(', ')} 지음`,
+    translatorNames.length > 0 ? `${translatorNames.join(', ')} 옮김` : null,
+    publisher,
+  ].filter(Boolean);
+
+  return (
+    <>
+      <HeaderLayout />
+
+      <section className="min-h-[calc(100dvh-6rem)] pb-12 flex flex-col gap-12 bg-zinc-100 dark:bg-zinc-900 *:bg-white *:dark:bg-zinc-800 group">
+        <div>
+          <div className="dark:bg-zinc-900">
+            <h3 className="py-2 text-lg font-semibold text-center">{title}</h3>
+            <div className="px-6 py-2 flex justify-between">
+              {width && height ? (
+                <Image
+                  src={thumbnail}
+                  alt={title}
+                  className="border shadow-xl"
+                  width={IMAGE_ASPECT_RATIO.WIDTH * SCALE_FACTOR}
+                  height={IMAGE_ASPECT_RATIO.HEIGHT * SCALE_FACTOR}
+                  priority
+                />
+              ) : (
+                <InvalidThumbnail />
+              )}
+              <div className="flex flex-col justify-end items-end *:text-neutral-500 *:text-sm">
+                <span>{formatKoreanDate(datetime)}</span>
+                <span>{price.toLocaleString('ko-KR')}원</span>
+                <span>{isbn.split(' ')[1]}</span>
+              </div>
+            </div>
+          </div>
+          <div className={containerStyles}>
+            {basicInfoItems.map((item, index) => (
+              <p key={index} className={itemStyles}>
+                {item}
+              </p>
+            ))}
+          </div>
+        </div>
+
+        <div className={containerStyles}>
+          <p className={`flex ${itemStyles}`}>
+            <StarRating rating={rating} bookId={bookId} readOnly />
+          </p>
+        </div>
+
+        <div data-before="한 줄 평" className={`${beforePseudoElementStyles} ${containerStyles}`}>
+          <div className={itemStyles}>
+            {review ? <p>{review}</p> : <p className="text-zinc-400">작성된 한 줄 평이 없습니다.</p>}
+          </div>
+        </div>
+
+        <div data-before="등록일" className={`${beforePseudoElementStyles} ${containerStyles}`}>
+          <p className={itemStyles}>{formatKoreanDate(created_at)}</p>
+        </div>
+
+        <div
+          data-before="도서 정보는 Daum에서 제공합니다."
+          className={`${beforePseudoElementStyles} ${containerStyles}`}
+        >
+          <Link href={url} className="text-neutral-900 dark:text-gray-100">
+            <p className={itemStyles}>Daum 검색에서 보기</p>
+          </Link>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/app/(bookshelf)/yours/[userId]/page.tsx
+++ b/app/(bookshelf)/yours/[userId]/page.tsx
@@ -1,0 +1,47 @@
+import { notFound } from 'next/navigation';
+import HeaderLayout from '@/layout/header';
+import ReadOnlyBookThumbnail from '@/ui/bookshelf/readonly-book-thumbnail';
+import { getBooks } from '@/(bookshelf)/mine/actions';
+import { verifyFriendship } from '@/(bookshelf)/yours/actions';
+import db from '@/lib/db';
+
+type Props = { params: { userId: string } };
+
+export default async function FriendBookshelf({ params }: Props) {
+  const userId = Number(params.userId);
+  if (Number.isNaN(userId)) return notFound();
+
+  const isFriend = await verifyFriendship(userId);
+  if (!isFriend) return notFound();
+
+  const friend = await db.user.findUnique({
+    where: { id: userId },
+    select: { name: true },
+  });
+  if (!friend) return notFound();
+
+  const books = await getBooks(userId);
+
+  return (
+    <>
+      <HeaderLayout title={`${friend.name}의 책장`} />
+      <div className="flex justify-center p-6 md:p-10">
+        {books.length > 0 ? (
+          <div className="grid grid-cols-3 gap-x-8 gap-y-5 md:gap-x-14 md:gap-y-14">
+            {books.map((book) => (
+              <ReadOnlyBookThumbnail
+                key={book.id}
+                id={book.id}
+                thumbnail={book.thumbnail}
+                title={book.title}
+                basePath={`/yours/${userId}`}
+              />
+            ))}
+          </div>
+        ) : (
+          <p className="pt-10 text-neutral-500">아직 등록된 책이 없습니다.</p>
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/(bookshelf)/yours/[userId]/page.tsx
+++ b/app/(bookshelf)/yours/[userId]/page.tsx
@@ -14,13 +14,11 @@ export default async function FriendBookshelf({ params }: Props) {
   const isFriend = await verifyFriendship(userId);
   if (!isFriend) return notFound();
 
-  const friend = await db.user.findUnique({
-    where: { id: userId },
-    select: { name: true },
-  });
+  const [friend, books] = await Promise.all([
+    db.user.findUnique({ where: { id: userId }, select: { name: true } }),
+    getBooks(userId),
+  ]);
   if (!friend) return notFound();
-
-  const books = await getBooks(userId);
 
   return (
     <>

--- a/app/(bookshelf)/yours/actions.ts
+++ b/app/(bookshelf)/yours/actions.ts
@@ -102,14 +102,11 @@ export async function verifyFriendship(friendUserId: number): Promise<boolean> {
 }
 
 export async function verifyBookOwnership(userId: number, bookId: number): Promise<boolean> {
-  const bookshelf = await db.bookshelf.findUnique({
-    where: { ownerId: userId },
-    select: { id: true },
-  });
-  if (!bookshelf) return false;
-
   const book = await db.book.findFirst({
-    where: { id: bookId, bookshelfId: bookshelf.id },
+    where: {
+      id: bookId,
+      Bookshelf: { ownerId: userId },
+    },
   });
   return !!book;
 }

--- a/app/(bookshelf)/yours/actions.ts
+++ b/app/(bookshelf)/yours/actions.ts
@@ -1,0 +1,115 @@
+'use server';
+
+import db from '@/lib/db';
+import getSession from '@/lib/session';
+import type { FriendInfo } from '@/types/friends';
+
+export type FriendWithLatestBook = FriendInfo & {
+  latestBookTitle: string | null;
+  latestBookCreatedAt: Date | null;
+};
+
+export async function getFriendsWithLatestBook(): Promise<FriendWithLatestBook[]> {
+  const session = await getSession();
+  if (!session.id) throw new Error('로그인이 필요합니다.');
+  const userId = session.id;
+
+  const friendships = await db.friendship.findMany({
+    where: {
+      status: 'ACCEPTED',
+      OR: [{ requesterId: userId }, { receiverId: userId }],
+    },
+    include: {
+      requester: {
+        select: {
+          id: true,
+          username: true,
+          name: true,
+          avatar: true,
+          bookshelf: {
+            select: {
+              books: {
+                orderBy: { created_at: 'desc' },
+                take: 1,
+                select: { title: true, created_at: true },
+              },
+            },
+          },
+        },
+      },
+      receiver: {
+        select: {
+          id: true,
+          username: true,
+          name: true,
+          avatar: true,
+          bookshelf: {
+            select: {
+              books: {
+                orderBy: { created_at: 'desc' },
+                take: 1,
+                select: { title: true, created_at: true },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const friends = friendships.map((f) => {
+    const friend = f.requesterId === userId ? f.receiver : f.requester;
+    const latestBook = friend.bookshelf?.books[0] ?? null;
+
+    return {
+      friendshipId: f.id,
+      id: friend.id,
+      username: friend.username,
+      name: friend.name,
+      avatar: friend.avatar,
+      status: f.status,
+      createdAt: f.created_at,
+      latestBookTitle: latestBook?.title ?? null,
+      latestBookCreatedAt: latestBook?.created_at ?? null,
+    };
+  });
+
+  friends.sort((a, b) => {
+    if (!a.latestBookCreatedAt && !b.latestBookCreatedAt) return 0;
+    if (!a.latestBookCreatedAt) return 1;
+    if (!b.latestBookCreatedAt) return -1;
+    return b.latestBookCreatedAt.getTime() - a.latestBookCreatedAt.getTime();
+  });
+
+  return friends;
+}
+
+export async function verifyFriendship(friendUserId: number): Promise<boolean> {
+  const session = await getSession();
+  if (!session.id) return false;
+
+  const friendship = await db.friendship.findFirst({
+    where: {
+      status: 'ACCEPTED',
+      OR: [
+        { requesterId: session.id, receiverId: friendUserId },
+        { requesterId: friendUserId, receiverId: session.id },
+      ],
+    },
+  });
+
+  return !!friendship;
+}
+
+export async function verifyBookOwnership(userId: number, bookId: number): Promise<boolean> {
+  const bookshelf = await db.bookshelf.findUnique({
+    where: { ownerId: userId },
+    select: { id: true },
+  });
+  if (!bookshelf) return false;
+
+  const book = await db.book.findFirst({
+    where: { id: bookId, bookshelfId: bookshelf.id },
+  });
+  return !!book;
+}

--- a/app/(bookshelf)/yours/page.tsx
+++ b/app/(bookshelf)/yours/page.tsx
@@ -1,15 +1,37 @@
 import Link from 'next/link';
 import { PlusIcon } from '@heroicons/react/24/outline';
 import HeaderLayout from '@/layout/header';
+import FriendBookshelfCard from '@/ui/bookshelf/yours/friend-bookshelf-card';
+import { getFriendsWithLatestBook } from '@/(bookshelf)/yours/actions';
 
-export default function Yours() {
+export default async function Yours() {
+  const friends = await getFriendsWithLatestBook();
+
   return (
     <>
       <HeaderLayout title="친구 책장" leftItem={<AddFriend />} />
-      <div className="pt-10 flex-col flex-center gap-2">
-        <p>준비 중인 기능입니다.</p>
-        <p>조금만 기다려 주세요 👀</p>
-      </div>
+      {friends.length > 0 ? (
+        <ul className="px-4">
+          {friends.map((friend) => (
+            <li key={friend.friendshipId}>
+              <FriendBookshelfCard friend={friend} />
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="pt-20 flex-col flex-center gap-4">
+          <div className="flex-col flex-center *:text-neutral-500">
+            <p>아직 친구가 없습니다.</p>
+            <p>친구를 추가하고 친구의 책장을 구경해보세요!</p>
+          </div>
+          <Link
+            href="/friends/add"
+            className="px-3 rounded-full border border-main-theme-color dark:border-blue-500 text-main-theme-color dark:text-blue-500"
+          >
+            친구 추가하기
+          </Link>
+        </div>
+      )}
     </>
   );
 }

--- a/app/constants/style.ts
+++ b/app/constants/style.ts
@@ -6,7 +6,7 @@ export const IMAGE_ASPECT_RATIO = {
 };
 export const SCALE_FACTOR = 4;
 
-export const containerStyles = 'px-4 flex flex-col gap-2 border-y-[1px] dark:border-neutral-700';
-export const itemStyles = 'py-3 border-b-[1px] last:border-b-0 dark:border-neutral-700';
+export const containerStyles = 'px-4 flex flex-col gap-2 border-y-[1px] border-neutral-200 dark:border-neutral-700';
+export const itemStyles = 'py-3 border-b-[1px] border-neutral-200 last:border-b-0 dark:border-neutral-700';
 export const beforePseudoElementStyles =
   'before:content-[attr(data-before)] before:absolute before:-translate-y-8 before:text-neutral-500';

--- a/app/friends/add/page.tsx
+++ b/app/friends/add/page.tsx
@@ -72,7 +72,7 @@ function AddFriendContent() {
 
       {/* Note: `pt-12` - header height만큼 공간 확보 + page section의 자체 패딩 */}
       <section className="pt-16 px-3 pb-4">
-        <SearchForm onSubmit={handleSubmit} />
+        <SearchForm onSubmit={handleSubmit} placeholder="친구 이름을 입력하세요" />
 
         {searched && results.length > 0 ? (
           <ul className="mt-3">

--- a/app/ui/books/search-form.tsx
+++ b/app/ui/books/search-form.tsx
@@ -2,12 +2,13 @@ import Search from '@/ui/search';
 
 type Props = {
   onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  placeholder?: string;
 };
 
-export default function SearchForm({ onSubmit }: Props) {
+export default function SearchForm({ onSubmit, placeholder }: Props) {
   return (
     <form onSubmit={onSubmit} className="flex gap-2">
-      <Search wrapperClassName="flex-grow basis-4/5" />
+      <Search wrapperClassName="flex-grow basis-4/5" placeholder={placeholder} />
       <button className="flex-grow basis-1/5 primary-btn px-4 py-2 dark:bg-blue-600 dark:hover:bg-blue-500">
         검색
       </button>

--- a/app/ui/books/star-rating.tsx
+++ b/app/ui/books/star-rating.tsx
@@ -6,14 +6,16 @@ import { StarIcon as SolidStarIcon } from '@heroicons/react/24/solid';
 import { updateRating } from '@/(bookshelf)/mine/[id]/actions';
 
 const MAX_RATING = 5;
-const starIconStyles = 'size-5 text-sky-600 dark:text-blue-500 cursor-pointer';
-
 type Props = {
   rating: number;
   bookId: number;
+  readOnly?: boolean;
 };
 
-export default function StarRating({ rating, bookId }: Props) {
+export default function StarRating({ rating, bookId, readOnly = false }: Props) {
+  const starIconStyles = readOnly
+    ? 'size-5 text-sky-600 dark:text-blue-500'
+    : 'size-5 text-sky-600 dark:text-blue-500 cursor-pointer';
   const updateFn = (_: number, newRating: number) => newRating;
   const [optimisticRating, setOptimisticRating] = useOptimistic(rating, updateFn);
 
@@ -46,10 +48,11 @@ export default function StarRating({ rating, bookId }: Props) {
   };
 
   const stars = Array.from({ length: MAX_RATING }, (_, index) => {
+    const handleClick = readOnly ? undefined : () => onClick(index);
     return index < optimisticRating ? (
-      <SolidStarIcon key={index} className={starIconStyles} onClick={() => onClick(index)} />
+      <SolidStarIcon key={index} className={starIconStyles} onClick={handleClick} />
     ) : (
-      <StarIcon key={index} className={starIconStyles} onClick={() => onClick(index)} />
+      <StarIcon key={index} className={starIconStyles} onClick={handleClick} />
     );
   });
 

--- a/app/ui/bookshelf/readonly-book-thumbnail.tsx
+++ b/app/ui/bookshelf/readonly-book-thumbnail.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import InvalidThumbnail from '@/ui/invalid-thumbnail';
+import { getImageSize } from '@/utils/image';
+import { IMAGE_ASPECT_RATIO } from '@/constants/style';
+
+const SCALE_FACTOR = 4;
+
+type Props = { id: number; thumbnail: string; title: string; basePath: string };
+
+export default function ReadOnlyBookThumbnail({ id, thumbnail, title, basePath }: Props) {
+  const { width, height } = getImageSize(thumbnail);
+
+  if (!width || !height) {
+    return <InvalidThumbnail />;
+  }
+
+  return (
+    <Link
+      href={{
+        pathname: `${basePath}/${id}`,
+        query: { thumbnail, title },
+      }}
+      className="cursor-pointer"
+    >
+      <Image
+        src={thumbnail}
+        alt={title}
+        className="shadow-lg md:scale-125"
+        width={IMAGE_ASPECT_RATIO.WIDTH * SCALE_FACTOR}
+        height={IMAGE_ASPECT_RATIO.HEIGHT * SCALE_FACTOR}
+      />
+    </Link>
+  );
+}

--- a/app/ui/bookshelf/readonly-book-thumbnail.tsx
+++ b/app/ui/bookshelf/readonly-book-thumbnail.tsx
@@ -2,9 +2,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import InvalidThumbnail from '@/ui/invalid-thumbnail';
 import { getImageSize } from '@/utils/image';
-import { IMAGE_ASPECT_RATIO } from '@/constants/style';
-
-const SCALE_FACTOR = 4;
+import { IMAGE_ASPECT_RATIO, SCALE_FACTOR } from '@/constants/style';
 
 type Props = { id: number; thumbnail: string; title: string; basePath: string };
 

--- a/app/ui/bookshelf/yours/friend-bookshelf-card.tsx
+++ b/app/ui/bookshelf/yours/friend-bookshelf-card.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import type { FriendWithLatestBook } from '@/(bookshelf)/yours/actions';
+
+type Props = { friend: FriendWithLatestBook };
+
+export default function FriendBookshelfCard({ friend }: Props) {
+  return (
+    <Link href={`/yours/${friend.id}`}>
+      <div className="py-3 flex items-center gap-3">
+        {friend.avatar ? (
+          <Image
+            src={friend.avatar}
+            alt={friend.name}
+            width={48}
+            height={48}
+            className="size-12 rounded-full object-cover"
+          />
+        ) : (
+          <div className="size-12 bg-gray-100 rounded-full" />
+        )}
+        <div className="flex flex-col min-w-0">
+          <span className="font-semibold">{friend.name}</span>
+          {friend.latestBookTitle ? (
+            <span className="text-sm text-neutral-500 truncate">최근에 추가한 책: {friend.latestBookTitle}</span>
+          ) : (
+            <span className="text-sm text-neutral-400">아직 등록된 책이 없습니다</span>
+          )}
+        </div>
+      </div>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
- 친구 목록에서 친구의 책장을 읽기 전용으로 구경할 수 있는 기능 추가
- 책 목록 정렬을 최신 추가순(created_at desc)으로 변경 (`/mine`, `/yours` 공통)
- 친구가 아닌 유저의 책장 접근 시 404 처리 (권한 체크)

## 주요 변경사항
- **`/yours`**: 친구 목록을 "최근 책 추가순"으로 표시, 각 친구의 최근 책 제목 미리보기
- **`/yours/[userId]`**: 친구 책장 그리드 (읽기 전용, 추가/편집/삭제 없음)
- **`/yours/[userId]/[id]`**: 친구 책 상세 (별점 표시만, 리뷰 읽기만, 삭제 버튼 없음)
- **StarRating**: `readOnly` prop 추가
- **보안**: `verifyFriendship` + `verifyBookOwnership`으로 권한 검증

## Test plan
- [x] 친구 책장 탭 → 친구 목록이 최근 책 추가순으로 표시되는지 확인
- [x] 친구 카드에 최근 책 제목 미리보기 표시 확인
- [x] 친구 탭 → 책장 그리드 → 책 상세 플로우 확인
- [x] 책 상세에서 별점/리뷰가 읽기 전용인지 확인
- [ ] URL 직접 입력으로 친구가 아닌 유저 책장 접근 시 404 확인
- [x] `/mine`에서 최신 추가순 정렬 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)