### PR TITLE
feat: 친구 신청 배지 표시

### DIFF
--- a/app/(bookshelf)/layout.tsx
+++ b/app/(bookshelf)/layout.tsx
@@ -1,10 +1,13 @@
 import BottomNav from '@/ui/nav/bottom-nav';
+import { getPendingRequestCount } from '@/friends/actions';
 
-export default function SharedLayout({ children }: { children: React.ReactNode }) {
+export default async function SharedLayout({ children }: { children: React.ReactNode }) {
+  const pendingCount = await getPendingRequestCount();
+
   return (
     <>
       <section className="pt-12 pb-12">{children}</section>
-      <BottomNav />
+      <BottomNav pendingRequestCount={pendingCount} />
     </>
   );
 }

--- a/app/(bookshelf)/settings/friends/page.tsx
+++ b/app/(bookshelf)/settings/friends/page.tsx
@@ -25,7 +25,12 @@ export default async function FriendsSettings() {
         <Tabs defaultValue="list">
           <TabsList>
             <TabsTrigger value="list">목록</TabsTrigger>
-            <TabsTrigger value="request">신청</TabsTrigger>
+            <TabsTrigger value="request">
+              <span className="relative">
+                신청
+                {requests.length > 0 && <span className="absolute top-0 -right-3 w-2 h-2 rounded-full bg-red-500" />}
+              </span>
+            </TabsTrigger>
           </TabsList>
 
           <TabsContent value="list">

--- a/app/(bookshelf)/settings/page.tsx
+++ b/app/(bookshelf)/settings/page.tsx
@@ -3,12 +3,15 @@ import { redirect } from 'next/navigation';
 import { ChevronRightIcon } from '@heroicons/react/24/outline';
 import getSession from '@/lib/session';
 import HeaderLayout from '@/layout/header';
+import { getPendingRequestCount } from '@/friends/actions';
 
 const containerStyles = 'px-4 py-3 flex justify-between';
 const beforePseudoElementStyles =
   'before:content-[attr(data-before)] before:absolute before:-translate-y-10 before:text-neutral-500';
 
 export default async function Settings() {
+  const pendingCount = await getPendingRequestCount();
+
   const logout = async () => {
     'use server';
     const session = await getSession();
@@ -31,7 +34,10 @@ export default async function Settings() {
             <ChevronRightIcon className="size-5 text-zinc-400" />
           </Link>
           <Link href="/settings/friends" className={containerStyles} scroll={false}>
-            <span>친구 관리</span>
+            <span className="relative">
+              친구 관리
+              {pendingCount > 0 && <span className="absolute top-0 -right-3 w-2 h-2 rounded-full bg-red-500" />}
+            </span>
             <ChevronRightIcon className="size-5 text-zinc-400" />
           </Link>
         </div>

--- a/app/friends/actions.ts
+++ b/app/friends/actions.ts
@@ -162,6 +162,17 @@ export async function getFriendsList(): Promise<FriendInfo[]> {
   });
 }
 
+export async function getPendingRequestCount(): Promise<number> {
+  const userId = await getSessionUserId();
+
+  return db.friendship.count({
+    where: {
+      receiverId: userId,
+      status: 'PENDING',
+    },
+  });
+}
+
 export async function getPendingRequests(): Promise<FriendInfo[]> {
   const userId = await getSessionUserId();
 

--- a/app/ui/nav/bottom-nav.tsx
+++ b/app/ui/nav/bottom-nav.tsx
@@ -1,9 +1,9 @@
 import NavLinks from '@/ui/nav/nav-links';
 
-export default function BottomNav() {
+export default function BottomNav({ pendingRequestCount }: { pendingRequestCount: number }) {
   return (
     <nav>
-      <NavLinks />
+      <NavLinks pendingRequestCount={pendingRequestCount} />
     </nav>
   );
 }

--- a/app/ui/nav/nav-links.tsx
+++ b/app/ui/nav/nav-links.tsx
@@ -21,7 +21,7 @@ const links = [
   { name: '설정', href: '/settings', defaultIcon: Cog6ToothIcon, selectedIcon: SolidCog6ToothIcon },
 ];
 
-export default function NavLinks() {
+export default function NavLinks({ pendingRequestCount }: { pendingRequestCount: number }) {
   const pathname = usePathname();
 
   return (
@@ -34,13 +34,16 @@ export default function NavLinks() {
         return (
           <li key={`link-${index}`} className="h-10 md:h-12 px-3 flex-center grow gap-2 rounded-md text-xs font-medium">
             <Link href={link.href} scroll={false} className="text-main-theme-color dark:text-gray-100">
-              <div className="flex flex-col items-center">
+              <div className="flex flex-col items-center relative">
                 {pathname.startsWith(link.href) ? (
                   <SelectedLinkIcon className="w-6" />
                 ) : (
                   <DefaultLinkIcon className="w-6" />
                 )}
                 <span>{link.name}</span>
+                {link.href === '/settings' && pendingRequestCount > 0 && (
+                  <span className="absolute -top-0.5 -right-1.5 w-2 h-2 rounded-full bg-red-500" />
+                )}
               </div>
             </Link>
           </li>


### PR DESCRIPTION
## Summary
- 대기 중인 친구 신청이 있을 때 빨간 점 배지를 표시하여 사용자가 쉽게 인지할 수 있도록 개선
- 하단 네비 설정 아이콘, 설정 페이지 친구 관리 메뉴, 친구 관리 페이지 신청 탭 3곳에 배지 적용
- 배지용 경량 서버 액션 `getPendingRequestCount()` 추가 (count 쿼리만 사용)

## Test plan
- [x] pending 요청이 있을 때 하단 네비 설정 아이콘에 빨간 점 표시 확인
- [x] 설정 페이지 친구 관리 옆 빨간 점 표시 확인
- [x] 친구 관리 페이지 신청 탭 옆 빨간 점 표시 확인
- [x] pending 요청이 없을 때 빨간 점 미표시 확인
- [x] 수락/거절 후 페이지 갱신 시 배지 사라지는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)