### PR TITLE
feat: 책 대출/반납 기능

### DIFF
--- a/app/(bookshelf)/loan/actions.ts
+++ b/app/(bookshelf)/loan/actions.ts
@@ -1,0 +1,83 @@
+'use server';
+
+import db from '@/lib/db';
+import getSession from '@/lib/session';
+import { revalidateTag } from 'next/cache';
+
+async function getSessionUserId() {
+  const session = await getSession();
+  if (!session.id) throw new Error('로그인이 필요합니다.');
+  return session.id;
+}
+
+export async function createLoan(
+  bookId: number,
+  borrowerId?: number,
+  borrowerName?: string,
+) {
+  const userId = await getSessionUserId();
+
+  // 소유권 검증
+  const book = await db.book.findFirst({
+    where: {
+      id: bookId,
+      Bookshelf: { ownerId: userId },
+    },
+  });
+  if (!book) throw new Error('본인 소유의 책만 대출할 수 있습니다.');
+
+  // 중복 대출 방지
+  const activeLoan = await db.loan.findFirst({
+    where: { bookId, returned_at: null },
+  });
+  if (activeLoan) throw new Error('이미 대출 중인 책입니다.');
+
+  // 등록된 친구인 경우 친구 관계 검증
+  if (borrowerId) {
+    const friendship = await db.friendship.findFirst({
+      where: {
+        status: 'ACCEPTED',
+        OR: [
+          { requesterId: userId, receiverId: borrowerId },
+          { requesterId: borrowerId, receiverId: userId },
+        ],
+      },
+    });
+    if (!friendship) throw new Error('친구 관계가 아닙니다.');
+  }
+
+  await db.loan.create({
+    data: {
+      bookId,
+      lenderId: userId,
+      borrowerId: borrowerId ?? null,
+      borrowerName: borrowerName ?? null,
+    },
+  });
+
+  revalidateTag(`book-${bookId}`);
+  revalidateTag('my-book-list');
+}
+
+export async function returnLoan(loanId: number) {
+  const userId = await getSessionUserId();
+
+  const loan = await db.loan.findUnique({
+    where: { id: loanId },
+  });
+
+  if (!loan) throw new Error('대출 정보를 찾을 수 없습니다.');
+  if (loan.returned_at) throw new Error('이미 반납된 책입니다.');
+  if (loan.lenderId !== userId && loan.borrowerId !== userId) {
+    throw new Error('반납 권한이 없습니다.');
+  }
+
+  await db.loan.update({
+    where: { id: loanId },
+    data: { returned_at: new Date() },
+  });
+
+  revalidateTag(`book-${loan.bookId}`);
+  revalidateTag('my-book-list');
+}
+

--- a/app/(bookshelf)/loan/queries.ts
+++ b/app/(bookshelf)/loan/queries.ts
@@ -1,0 +1,33 @@
+import db from '@/lib/db';
+
+export async function getActiveLoan(bookId: number) {
+  return db.loan.findFirst({
+    where: { bookId, returned_at: null },
+    include: {
+      borrower: { select: { id: true, name: true } },
+      lender: { select: { id: true, name: true } },
+    },
+  });
+}
+
+export async function getBorrowedBooks(userId: number) {
+  const loans = await db.loan.findMany({
+    where: { borrowerId: userId, returned_at: null },
+    orderBy: { lent_at: 'desc' },
+    include: {
+      book: true,
+      lender: { select: { id: true, name: true } },
+    },
+  });
+
+  return loans;
+}
+
+export async function getLentBookIds(userId: number) {
+  const loans = await db.loan.findMany({
+    where: { lenderId: userId, returned_at: null },
+    select: { bookId: true },
+  });
+
+  return loans.map((loan) => loan.bookId);
+}

--- a/app/(bookshelf)/mine/[id]/page.tsx
+++ b/app/(bookshelf)/mine/[id]/page.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
 import { unstable_cache as nextCache } from 'next/cache';
 import { notFound } from 'next/navigation';
 import { getBook, updateReview } from '@/(bookshelf)/mine/[id]/actions';
@@ -14,7 +16,6 @@ import LoanInfoSection from '@/ui/books/loan-info-section';
 import ReturnBookButton from '@/ui/books/return-book-button';
 import StarRating from '@/ui/books/star-rating';
 import { getImageSize } from '@/utils/image';
-import { formatKoreanDate } from '@/utils/date';
 import {
   IMAGE_ASPECT_RATIO,
   SCALE_FACTOR,
@@ -86,7 +87,7 @@ export default async function BookDetail({ params }: Props) {
                 <InvalidThumbnail />
               )}
               <div className="flex flex-col justify-end items-end *:text-neutral-500 *:text-sm">
-                <span>{formatKoreanDate(datetime)}</span>
+                <span>{format(datetime, 'yyyy년 M월 d일', { locale: ko })}</span>
                 <span>{price.toLocaleString('ko-KR')}원</span>
                 <span>{isbn.split(' ')[1]}</span>
               </div>
@@ -116,7 +117,7 @@ export default async function BookDetail({ params }: Props) {
         </div>
 
         <div data-before="등록일" className={`${beforePseudoElementStyles} ${containerStyles}`}>
-          <p className={itemStyles}>{formatKoreanDate(created_at)}</p>
+          <p className={itemStyles}>{format(created_at, 'yyyy년 M월 d일', { locale: ko })}</p>
         </div>
 
         <div

--- a/app/(bookshelf)/yours/[userId]/[id]/page.tsx
+++ b/app/(bookshelf)/yours/[userId]/[id]/page.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
 import { notFound } from 'next/navigation';
 import { getBook } from '@/(bookshelf)/mine/[id]/actions';
 import { getActiveLoan } from '@/(bookshelf)/loan/queries';
@@ -12,7 +14,6 @@ import LoanInfoSection from '@/ui/books/loan-info-section';
 import ReturnBookButton from '@/ui/books/return-book-button';
 import StarRating from '@/ui/books/star-rating';
 import { getImageSize } from '@/utils/image';
-import { formatKoreanDate } from '@/utils/date';
 import {
   IMAGE_ASPECT_RATIO,
   SCALE_FACTOR,
@@ -79,7 +80,7 @@ export default async function FriendBookDetail({ params }: Props) {
                 <InvalidThumbnail />
               )}
               <div className="flex flex-col justify-end items-end *:text-neutral-500 *:text-sm">
-                <span>{formatKoreanDate(datetime)}</span>
+                <span>{format(datetime, 'yyyy년 M월 d일', { locale: ko })}</span>
                 <span>{price.toLocaleString('ko-KR')}원</span>
                 <span>{isbn.split(' ')[1]}</span>
               </div>
@@ -115,7 +116,7 @@ export default async function FriendBookDetail({ params }: Props) {
         )}
 
         <div data-before="등록일" className={`${beforePseudoElementStyles} ${containerStyles}`}>
-          <p className={itemStyles}>{formatKoreanDate(created_at)}</p>
+          <p className={itemStyles}>{format(created_at, 'yyyy년 M월 d일', { locale: ko })}</p>
         </div>
 
         <div

--- a/app/(bookshelf)/yours/[userId]/[id]/page.tsx
+++ b/app/(bookshelf)/yours/[userId]/[id]/page.tsx
@@ -2,9 +2,14 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { notFound } from 'next/navigation';
 import { getBook } from '@/(bookshelf)/mine/[id]/actions';
+import { getActiveLoan } from '@/(bookshelf)/loan/queries';
 import { verifyFriendship, verifyBookOwnership } from '@/(bookshelf)/yours/actions';
+import { getUser } from '@/lib/data';
 import HeaderLayout from '@/layout/header';
 import InvalidThumbnail from '@/ui/invalid-thumbnail';
+import BookLoanTag from '@/ui/bookshelf/book-loan-tag';
+import LoanInfoSection from '@/ui/books/loan-info-section';
+import ReturnBookButton from '@/ui/books/return-book-button';
 import StarRating from '@/ui/books/star-rating';
 import { getImageSize } from '@/utils/image';
 import { formatKoreanDate } from '@/utils/date';
@@ -26,11 +31,15 @@ export default async function FriendBookDetail({ params }: Props) {
   const isFriend = await verifyFriendship(userId);
   if (!isFriend) return notFound();
 
-  const [isOwner, book] = await Promise.all([
+  const [isOwner, book, activeLoan, currentUser] = await Promise.all([
     verifyBookOwnership(userId, bookId),
     getBook(bookId),
+    getActiveLoan(bookId),
+    getUser(),
   ]);
   if (!isOwner || !book) return notFound();
+
+  const isBorrower = activeLoan && currentUser && activeLoan.borrowerId === currentUser.id;
 
   const { title, thumbnail, datetime, price, authors, translators, publisher, url, isbn, rating, review, created_at } =
     book;
@@ -55,14 +64,17 @@ export default async function FriendBookDetail({ params }: Props) {
             <h3 className="py-2 text-lg font-semibold text-center">{title}</h3>
             <div className="px-6 py-2 flex justify-between">
               {width && height ? (
-                <Image
-                  src={thumbnail}
-                  alt={title}
-                  className="border shadow-xl"
-                  width={IMAGE_ASPECT_RATIO.WIDTH * SCALE_FACTOR}
-                  height={IMAGE_ASPECT_RATIO.HEIGHT * SCALE_FACTOR}
-                  priority
-                />
+                <div className="relative">
+                  {isBorrower && <BookLoanTag type="borrowed" />}
+                  <Image
+                    src={thumbnail}
+                    alt={title}
+                    className="border shadow-xl"
+                    width={IMAGE_ASPECT_RATIO.WIDTH * SCALE_FACTOR}
+                    height={IMAGE_ASPECT_RATIO.HEIGHT * SCALE_FACTOR}
+                    priority
+                  />
+                </div>
               ) : (
                 <InvalidThumbnail />
               )}
@@ -82,17 +94,25 @@ export default async function FriendBookDetail({ params }: Props) {
           </div>
         </div>
 
-        <div className={containerStyles}>
-          <p className={`flex ${itemStyles}`}>
-            <StarRating rating={rating} bookId={bookId} readOnly />
-          </p>
-        </div>
+        {isBorrower && activeLoan.lender && (
+          <LoanInfoSection type="borrowed" personName={activeLoan.lender.name} lentAt={activeLoan.lent_at} />
+        )}
 
-        <div data-before="한 줄 평" className={`${beforePseudoElementStyles} ${containerStyles}`}>
-          <div className={itemStyles}>
-            {review ? <p>{review}</p> : <p className="text-zinc-400">작성된 한 줄 평이 없습니다.</p>}
-          </div>
-        </div>
+        {!isBorrower && (
+          <>
+            <div className={containerStyles}>
+              <p className={`flex ${itemStyles}`}>
+                <StarRating rating={rating} bookId={bookId} readOnly />
+              </p>
+            </div>
+
+            <div data-before="한 줄 평" className={`${beforePseudoElementStyles} ${containerStyles}`}>
+              <div className={itemStyles}>
+                {review ? <p>{review}</p> : <p className="text-zinc-400">작성된 한 줄 평이 없습니다.</p>}
+              </div>
+            </div>
+          </>
+        )}
 
         <div data-before="등록일" className={`${beforePseudoElementStyles} ${containerStyles}`}>
           <p className={itemStyles}>{formatKoreanDate(created_at)}</p>
@@ -106,6 +126,8 @@ export default async function FriendBookDetail({ params }: Props) {
             <p className={itemStyles}>Daum 검색에서 보기</p>
           </Link>
         </div>
+
+        {isBorrower && <ReturnBookButton loanId={activeLoan.id} redirectTo="/mine" />}
       </section>
     </>
   );

--- a/app/types/loan.ts
+++ b/app/types/loan.ts
@@ -1,0 +1,1 @@
+export type LoanStatus = 'lent' | 'borrowed';

--- a/app/ui/books/cards.tsx
+++ b/app/ui/books/cards.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
 import { CheckIcon } from '@heroicons/react/24/outline';
-import { formatKoreanDate } from '@/utils/date';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
 import { createBook, getMoreBooks, type KaKaoBookResponse } from '@/books/add/list/actions';
 import { IMAGE_ASPECT_RATIO } from '@/constants/style';
 
@@ -121,7 +122,7 @@ function BookCard({
             {translators.length > 0 && `${translators.join(', ')} 옮김`}
           </span>
           <span>{publisher}</span>
-          <span className="">{formatKoreanDate(datetime)}</span>
+          <span className="">{format(datetime, 'yyyy년 M월 d일', { locale: ko })}</span>
         </div>
       </div>
       <div

--- a/app/ui/books/delete-book-button.tsx
+++ b/app/ui/books/delete-book-button.tsx
@@ -16,7 +16,7 @@ export default function DeleteBookButton({ bookId }: { bookId: number }) {
 
   return (
     <>
-      <div className="pb-10 flex justify-center group-last:bg-inherit">
+      <div className="flex justify-center group-last:bg-inherit">
         <button onClick={openModal} className="text-red-600">
           책 삭제
         </button>

--- a/app/ui/books/lend-book-button.tsx
+++ b/app/ui/books/lend-book-button.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useState } from 'react';
+import LendBookModal from '@/ui/modals/lend-book-modal';
+
+export default function LendBookButton({ bookId }: { bookId: number }) {
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <>
+      <div className="flex justify-center group-last:bg-inherit">
+        <button onClick={() => setShowModal(true)} className="text-blue-600">
+          친구에게 빌려주기
+        </button>
+      </div>
+      {showModal && <LendBookModal closeModal={() => setShowModal(false)} bookId={bookId} />}
+    </>
+  );
+}

--- a/app/ui/books/loan-info-section.tsx
+++ b/app/ui/books/loan-info-section.tsx
@@ -1,5 +1,6 @@
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
 import { containerStyles, itemStyles, beforePseudoElementStyles } from '@/constants/style';
-import { formatKoreanDate } from '@/utils/date';
 import type { LoanStatus } from '@/types/loan';
 
 type Props = {
@@ -16,7 +17,7 @@ export default function LoanInfoSection({ type, personName, lentAt }: Props) {
     <div data-before={label} className={`${beforePseudoElementStyles} ${containerStyles}`}>
       <div className={itemStyles}>
         <p>{description}</p>
-        <p className="text-sm text-neutral-500 mt-1">{formatKoreanDate(lentAt)}</p>
+        <p className="text-sm text-neutral-500 mt-1">{format(lentAt, 'yyyy년 M월 d일', { locale: ko })}</p>
       </div>
     </div>
   );

--- a/app/ui/books/loan-info-section.tsx
+++ b/app/ui/books/loan-info-section.tsx
@@ -1,0 +1,23 @@
+import { containerStyles, itemStyles, beforePseudoElementStyles } from '@/constants/style';
+import { formatKoreanDate } from '@/utils/date';
+import type { LoanStatus } from '@/types/loan';
+
+type Props = {
+  type: LoanStatus;
+  personName: string;
+  lentAt: Date;
+};
+
+export default function LoanInfoSection({ type, personName, lentAt }: Props) {
+  const label = '대출 정보';
+  const description = type === 'lent' ? `빌려간 사람: ${personName}` : `빌려준 사람: ${personName}`;
+
+  return (
+    <div data-before={label} className={`${beforePseudoElementStyles} ${containerStyles}`}>
+      <div className={itemStyles}>
+        <p>{description}</p>
+        <p className="text-sm text-neutral-500 mt-1">{formatKoreanDate(lentAt)}</p>
+      </div>
+    </div>
+  );
+}

--- a/app/ui/books/return-book-button.tsx
+++ b/app/ui/books/return-book-button.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useState } from 'react';
+import ReturnBookConfirmModal from '@/ui/modals/return-book-confirm-modal';
+
+type Props = {
+  loanId: number;
+  redirectTo?: string;
+};
+
+export default function ReturnBookButton({ loanId, redirectTo }: Props) {
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <>
+      <div className="flex justify-center group-last:bg-inherit">
+        <button onClick={() => setShowModal(true)} className="text-blue-600">
+          반납하기
+        </button>
+      </div>
+      {showModal && (
+        <ReturnBookConfirmModal closeModal={() => setShowModal(false)} loanId={loanId} redirectTo={redirectTo} />
+      )}
+    </>
+  );
+}

--- a/app/ui/bookshelf/book-loan-tag.tsx
+++ b/app/ui/bookshelf/book-loan-tag.tsx
@@ -5,14 +5,16 @@ type Props = {
 };
 
 const labels: Record<LoanStatus, string> = {
-  lent: '빌려준 책',
+  lent: '대출 중',
   borrowed: '빌린 책',
 };
 
 export default function BookLoanTag({ type }: Props) {
   return (
-    <span className="absolute top-0 left-0 z-10 px-1 text-[10px] font-semibold text-white bg-zinc-700/80">
-      {labels[type]}
-    </span>
+    <div className="absolute top-0 left-0 z-10 overflow-hidden w-14 h-14">
+      <span className="absolute top-1.5 -left-[22px] w-[72px] text-center text-[10px] font-semibold text-white bg-main-theme-color -rotate-45">
+        {labels[type]}
+      </span>
+    </div>
   );
 }

--- a/app/ui/bookshelf/book-loan-tag.tsx
+++ b/app/ui/bookshelf/book-loan-tag.tsx
@@ -1,0 +1,18 @@
+import type { LoanStatus } from '@/types/loan';
+
+type Props = {
+  type: LoanStatus;
+};
+
+const labels: Record<LoanStatus, string> = {
+  lent: '빌려준 책',
+  borrowed: '빌린 책',
+};
+
+export default function BookLoanTag({ type }: Props) {
+  return (
+    <span className="absolute top-0 left-0 z-10 px-1 text-[10px] font-semibold text-white bg-zinc-700/80">
+      {labels[type]}
+    </span>
+  );
+}

--- a/app/ui/bookshelf/book-thumbnail.tsx
+++ b/app/ui/bookshelf/book-thumbnail.tsx
@@ -5,15 +5,17 @@ import Image from 'next/image';
 import { useAtomValue, useAtom } from 'jotai';
 import { CheckCircleIcon } from '@heroicons/react/24/outline';
 import InvalidThumbnail from '@/ui//invalid-thumbnail';
+import BookLoanTag from '@/ui/bookshelf/book-loan-tag';
 import { getImageSize } from '@/utils/image';
 import { IMAGE_ASPECT_RATIO } from '@/constants/style';
 import { currentModeAtom, selectedItemsAtom } from '@/store/atoms';
+import type { LoanStatus } from '@/types/loan';
 
 const SCALE_FACTOR = 4;
 
-type Props = { id: number; thumbnail: string; title: string };
+type Props = { id: number; thumbnail: string; title: string; loanStatus?: LoanStatus | null };
 
-export default function BookThumbnail({ id, thumbnail, title }: Props) {
+export default function BookThumbnail({ id, thumbnail, title, loanStatus }: Props) {
   const { width, height } = getImageSize(thumbnail);
   const currentMode = useAtomValue(currentModeAtom);
   const [selectedItems, setSelectedItems] = useAtom(selectedItemsAtom);
@@ -34,37 +36,42 @@ export default function BookThumbnail({ id, thumbnail, title }: Props) {
     return <InvalidThumbnail />;
   }
 
+  const imageElement = (
+    <Image
+      src={thumbnail}
+      alt={title}
+      className="shadow-lg md:scale-125"
+      width={IMAGE_ASPECT_RATIO.WIDTH * SCALE_FACTOR}
+      height={IMAGE_ASPECT_RATIO.HEIGHT * SCALE_FACTOR}
+    />
+  );
+
   return currentMode === 'view' ? (
     <Link
       href={{
         pathname: `/mine/${id}`,
         query: { thumbnail, title },
       }}
-      className="cursor-pointer"
+      className="relative cursor-pointer"
     >
-      <Image
-        src={thumbnail}
-        alt={title}
-        className="shadow-lg md:scale-125"
-        width={IMAGE_ASPECT_RATIO.WIDTH * SCALE_FACTOR}
-        height={IMAGE_ASPECT_RATIO.HEIGHT * SCALE_FACTOR}
-      />
+      {loanStatus && <BookLoanTag type={loanStatus} />}
+      {imageElement}
     </Link>
+  ) : loanStatus === 'borrowed' ? (
+    <div className="relative opacity-50">
+      {loanStatus && <BookLoanTag type={loanStatus} />}
+      {imageElement}
+    </div>
   ) : (
     <div className="relative cursor-pointer" onClick={handleClick}>
+      {loanStatus && <BookLoanTag type={loanStatus} />}
       {isSelected && (
         <>
           <div className="absolute inset-0 bg-gray-300 opacity-50" /> {/* dimmed overlay */}
           <CheckCircleIcon className="absolute bottom-2 left-1/2 transform -translate-x-1/2 size-5 bg-red-600 text-white rounded-full" />
         </>
       )}
-      <Image
-        src={thumbnail}
-        alt={title}
-        className="shadow-lg md:scale-125"
-        width={IMAGE_ASPECT_RATIO.WIDTH * SCALE_FACTOR}
-        height={IMAGE_ASPECT_RATIO.HEIGHT * SCALE_FACTOR}
-      />
+      {imageElement}
     </div>
   );
 }

--- a/app/ui/bookshelf/readonly-book-thumbnail.tsx
+++ b/app/ui/bookshelf/readonly-book-thumbnail.tsx
@@ -1,12 +1,14 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import InvalidThumbnail from '@/ui/invalid-thumbnail';
+import BookLoanTag from '@/ui/bookshelf/book-loan-tag';
 import { getImageSize } from '@/utils/image';
 import { IMAGE_ASPECT_RATIO, SCALE_FACTOR } from '@/constants/style';
+import type { LoanStatus } from '@/types/loan';
 
-type Props = { id: number; thumbnail: string; title: string; basePath: string };
+type Props = { id: number; thumbnail: string; title: string; basePath: string; loanStatus?: LoanStatus | null };
 
-export default function ReadOnlyBookThumbnail({ id, thumbnail, title, basePath }: Props) {
+export default function ReadOnlyBookThumbnail({ id, thumbnail, title, basePath, loanStatus }: Props) {
   const { width, height } = getImageSize(thumbnail);
 
   if (!width || !height) {
@@ -19,8 +21,9 @@ export default function ReadOnlyBookThumbnail({ id, thumbnail, title, basePath }
         pathname: `${basePath}/${id}`,
         query: { thumbnail, title },
       }}
-      className="cursor-pointer"
+      className="relative cursor-pointer"
     >
+      {loanStatus && <BookLoanTag type={loanStatus} />}
       <Image
         src={thumbnail}
         alt={title}

--- a/app/ui/modals/lend-book-modal.tsx
+++ b/app/ui/modals/lend-book-modal.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Image from 'next/image';
+import Modal from '@/ui/modals/modal';
+import DefaultAvatar from '@/ui/default-avatar';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui';
+import { getFriendsList } from '@/friends/actions';
+import { createLoan } from '@/(bookshelf)/loan/actions';
+import type { FriendInfo } from '@/types/friends';
+
+type Props = {
+  closeModal: () => void;
+  bookId: number;
+};
+
+export default function LendBookModal({ closeModal, bookId }: Props) {
+  const [friends, setFriends] = useState<FriendInfo[]>([]);
+  const [selectedFriendId, setSelectedFriendId] = useState<number | null>(null);
+  const [manualName, setManualName] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [activeTab, setActiveTab] = useState('friend');
+
+  useEffect(() => {
+    getFriendsList().then((list) => {
+      setFriends(list.sort((a, b) => a.name.localeCompare(b.name, 'ko')));
+      setIsLoading(false);
+    });
+  }, []);
+
+  const handleConfirm = async () => {
+    try {
+      if (activeTab === 'friend' && selectedFriendId) {
+        await createLoan(bookId, selectedFriendId);
+      } else if (activeTab === 'manual' && manualName.trim()) {
+        await createLoan(bookId, undefined, manualName.trim());
+      }
+      closeModal();
+    } catch (error) {
+      alert(error instanceof Error ? error.message : '대출에 실패했습니다.');
+    }
+  };
+
+  return (
+    <Modal>
+      <Modal.Title>빌려주기</Modal.Title>
+      <div className="mt-3">
+        <Tabs defaultValue="friend" onValueChange={setActiveTab}>
+          <TabsList>
+            <TabsTrigger value="friend" className="data-[state=active]:border-blue-500">친구 선택</TabsTrigger>
+            <TabsTrigger value="manual" className="data-[state=active]:border-blue-500">직접 입력</TabsTrigger>
+          </TabsList>
+
+          <div className="h-48">
+            <TabsContent value="friend">
+              {isLoading ? (
+                <p className="text-sm text-gray-500 py-2">로딩 중...</p>
+              ) : friends.length === 0 ? (
+                <p className="text-sm text-gray-500 py-2">등록된 친구가 없습니다.</p>
+              ) : (
+                <ul className="max-h-40 overflow-y-auto">
+                  {friends.map((friend) => (
+                    <li key={friend.id}>
+                      <label className="py-1 flex items-center gap-2 cursor-pointer">
+                        <input
+                          type="radio"
+                          name="friend"
+                          checked={selectedFriendId === friend.id}
+                          onChange={() => setSelectedFriendId(friend.id)}
+                          className="accent-blue-500"
+                        />
+                        {friend.avatar ? (
+                          <Image
+                            src={friend.avatar}
+                            alt={friend.name}
+                            width={40}
+                            height={40}
+                            className="size-10 rounded-full object-cover"
+                          />
+                        ) : (
+                          <DefaultAvatar className="size-10" />
+                        )}
+                        <div className="flex flex-col">
+                          <span className="text-sm font-semibold">{friend.name}</span>
+                          <span className="text-xs text-neutral-500">
+                            {friend.username.slice(0, 5)} {friend.username.slice(5)}
+                          </span>
+                        </div>
+                      </label>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </TabsContent>
+
+            <TabsContent value="manual">
+              <input
+                type="text"
+                value={manualName}
+                onChange={(e) => setManualName(e.target.value)}
+                placeholder="빌려갈 사람 이름"
+                className="w-full px-3 py-2 text-sm border rounded-md dark:bg-zinc-800 dark:border-zinc-600"
+              />
+            </TabsContent>
+          </div>
+        </Tabs>
+      </div>
+      <Modal.Footer>
+        <Modal.CancelButton onClick={closeModal}>취소</Modal.CancelButton>
+        <Modal.OkButton onClick={handleConfirm}>확인</Modal.OkButton>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/app/ui/modals/return-book-confirm-modal.tsx
+++ b/app/ui/modals/return-book-confirm-modal.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import Modal from '@/ui/modals/modal';
+import { returnLoan } from '@/(bookshelf)/loan/actions';
+
+type Props = {
+  closeModal: () => void;
+  loanId: number;
+  redirectTo?: string;
+};
+
+export default function ReturnBookConfirmModal({ closeModal, loanId, redirectTo }: Props) {
+  const router = useRouter();
+
+  return (
+    <Modal>
+      <Modal.Title>반납 확인</Modal.Title>
+      <Modal.Description>이 책을 반납할까요?</Modal.Description>
+      <Modal.Footer>
+        <Modal.CancelButton onClick={closeModal}>취소</Modal.CancelButton>
+        <Modal.OkButton
+          onClick={async () => {
+            await returnLoan(loanId);
+            if (redirectTo) {
+              router.push(redirectTo);
+            } else {
+              router.refresh();
+              closeModal();
+            }
+          }}
+        >
+          확인
+        </Modal.OkButton>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/app/utils/date.ts
+++ b/app/utils/date.ts
@@ -1,8 +1,0 @@
-/**
- * @returns {string} 연월일 형식으로 포맷된 문자열 (예: '2024년 7월 18일')
- */
-export function formatKoreanDate(date: Date | string): string {
-  const transformedDate = typeof date === 'string' ? new Date(date) : date;
-
-  return transformedDate.toLocaleString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' });
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-tabs": "^1.1.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "date-fns": "^4.1.0",
         "iron-session": "^8.0.1",
         "jotai": "^2.9.3",
         "lucide-react": "^0.453.0",
@@ -1897,6 +1898,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-tabs": "^1.1.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "iron-session": "^8.0.1",
     "jotai": "^2.9.3",
     "lucide-react": "^0.453.0",

--- a/prisma/migrations/20260222024409_add_loan_model/migration.sql
+++ b/prisma/migrations/20260222024409_add_loan_model/migration.sql
@@ -1,0 +1,30 @@
+-- CreateTable
+CREATE TABLE "Loan" (
+    "id" SERIAL NOT NULL,
+    "bookId" INTEGER NOT NULL,
+    "lenderId" INTEGER NOT NULL,
+    "borrowerId" INTEGER,
+    "borrowerName" TEXT,
+    "lent_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "returned_at" TIMESTAMP(3),
+
+    CONSTRAINT "Loan_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Loan_bookId_idx" ON "Loan"("bookId");
+
+-- CreateIndex
+CREATE INDEX "Loan_lenderId_idx" ON "Loan"("lenderId");
+
+-- CreateIndex
+CREATE INDEX "Loan_borrowerId_idx" ON "Loan"("borrowerId");
+
+-- AddForeignKey
+ALTER TABLE "Loan" ADD CONSTRAINT "Loan_bookId_fkey" FOREIGN KEY ("bookId") REFERENCES "Book"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Loan" ADD CONSTRAINT "Loan_lenderId_fkey" FOREIGN KEY ("lenderId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Loan" ADD CONSTRAINT "Loan_borrowerId_fkey" FOREIGN KEY ("borrowerId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,9 @@ model User {
   // 친구 관계 필드 추가
   requester_friendships Friendship[] @relation("requester_friendships")
   receiver_friendships  Friendship[] @relation("receiver_friendships")
+  // 대출 관계 필드
+  lender_loans          Loan[]       @relation("lender_loans")
+  borrower_loans        Loan[]       @relation("borrower_loans")
 }
 
 model Bookshelf {
@@ -56,6 +59,7 @@ model Book {
   updated_at  DateTime         @updatedAt
   Bookshelf   Bookshelf        @relation(fields: [bookshelfId], references: [id])
   bookshelfId Int
+  loans       Loan[]
 }
 
 model Author {
@@ -107,4 +111,21 @@ model Friendship {
   @@unique([requesterId, receiverId]) // 동일한 사용자 간의 중복 요청 방지
   @@index([requesterId])
   @@index([receiverId])
+}
+
+model Loan {
+  id           Int       @id @default(autoincrement())
+  book         Book      @relation(fields: [bookId], references: [id], onDelete: Cascade)
+  bookId       Int
+  lender       User      @relation("lender_loans", fields: [lenderId], references: [id])
+  lenderId     Int
+  borrower     User?     @relation("borrower_loans", fields: [borrowerId], references: [id])
+  borrowerId   Int? // 미등록 친구면 null
+  borrowerName String? // 미등록 친구 이름
+  lent_at      DateTime  @default(now())
+  returned_at  DateTime? // null = 대출중, 값 있으면 반납 완료
+
+  @@index([bookId])
+  @@index([lenderId])
+  @@index([borrowerId])
 }


### PR DESCRIPTION
## Summary
- 친구에게 책을 빌려주고 반납받는 대출/반납 기능 추가
- 내 책장과 친구 책장에서 대출 상태를 리본 태그로 표시
- formatKoreanDate 유틸을 date-fns로 교체

## Changes
- Loan 모델 추가 및 DB 마이그레이션 (`prisma/schema.prisma`)
- 대출 생성/반납 서버 액션 (`loan/actions.ts`, `loan/queries.ts`)
- 대출 태그 리본 UI 컴포넌트 (`book-loan-tag.tsx`)
- 빌려주기 모달 (친구 선택 / 직접 입력 탭) (`lend-book-modal.tsx`)
- 반납 확인 모달 (`return-book-confirm-modal.tsx`)
- 내 책 상세 / 친구 책 상세 페이지에 대출 정보 섹션 표시
- 내 책장 목록에 빌린 책과 대출 중 태그 표시
- `formatKoreanDate` → `date-fns` `format()` 전환 및 `date-fns` 의존성 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)