### PR TITLE
fix: 대출 태그가 헤더 위에 겹치는 z-index 버그 수정

### DIFF
--- a/app/layout/header.tsx
+++ b/app/layout/header.tsx
@@ -11,7 +11,7 @@ type Props = {
 export default function HeaderLayout({ backButtonText = '뒤로', leftItem, title, rightItem }: Props) {
   return (
     <header
-      className={`w-full ${MAX_WIDTH} h-12 fixed top-0 left-1/2 transform -translate-x-1/2 py-4 flex-center bg-gray-50 dark:bg-zinc-700 border-b border-gray-200 dark:border-zinc-600 z-10`}
+      className={`w-full ${MAX_WIDTH} h-12 fixed top-0 left-1/2 transform -translate-x-1/2 py-4 flex-center bg-gray-50 dark:bg-zinc-700 border-b border-gray-200 dark:border-zinc-600 z-20`}
     >
       <div className="absolute left-2 text-main-theme-color dark:text-blue-500 *:text-main-theme-color *:dark:text-blue-500">
         {leftItem ? leftItem : <BackButton>{backButtonText}</BackButton>}


### PR DESCRIPTION
## Summary
- 대출 태그(z-10)가 고정 헤더(z-10) 위에 겹치는 버그 수정

## Changes
- 헤더의 z-index를 z-10에서 z-20으로 변경 (`app/layout/header.tsx`)